### PR TITLE
ENG-173925: Propagate server trace_id and POST body into the error message

### DIFF
--- a/cato.go
+++ b/cato.go
@@ -53,26 +53,27 @@ func New(url string, token string, accountId string, httpClient *http.Client, he
 		httpClient = retryClient.StandardClient()
 	}
 
-	catoClient := &Client{
-		Client: clientv2.NewClient(httpClient, url, nil,
-			func(ctx context.Context, req *http.Request, gqlInfo *clientv2.GQLRequestInfo, res any, next clientv2.RequestInterceptorFunc) error {
-				req.Header.Set("x-api-key", token)
-				req.Header.Set("x-account-id", accountId)
-				for key, val := range headers {
-					req.Header.Set(key, val)
-				}
+	gqlClient := clientv2.NewClient(httpClient, url, nil,
+		func(ctx context.Context, req *http.Request, gqlInfo *clientv2.GQLRequestInfo, res any, next clientv2.RequestInterceptorFunc) error {
+			req.Header.Set("x-api-key", token)
+			req.Header.Set("x-account-id", accountId)
+			for key, val := range headers {
+				req.Header.Set(key, val)
+			}
 
-				// set a user-agent if not set by client
-				_, exists := headers["User-Agent"]
-				if !exists {
-					req.Header.Set("User-Agent", "Cato_Go_SDK/v0")
-				}
+			// set a user-agent if not set by client
+			_, exists := headers["User-Agent"]
+			if !exists {
+				req.Header.Set("User-Agent", "Cato_Go_SDK/v0")
+			}
 
-				return next(ctx, req, gqlInfo, res)
-			}),
+			return next(ctx, req, gqlInfo, res)
+		})
+	gqlClient.CustomDo = func(ctx context.Context, req *http.Request, gqlInfo *clientv2.GQLRequestInfo, res any) error {
+		return executeGQLWithTrace(ctx, gqlClient, req, gqlInfo, res)
 	}
 
-	return catoClient, nil
+	return &Client{Client: gqlClient}, nil
 }
 
 func baseRetryPolicy(ctx context.Context, resp *http.Response, err error) (bool, error) {

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,49 @@
+package cato_go_sdk
+
+import (
+	"errors"
+	"fmt"
+)
+
+// APIError represents an API call failure and includes the API trace ID
+// when the server returns one (Trace_id response header), for root cause analysis and support.
+// Clients created with New attach the trace ID to errors from failed GraphQL calls automatically.
+type APIError struct {
+	Err         error
+	TraceID     string
+	RequestBody string
+}
+
+func (e *APIError) Error() string {
+	msg := e.Err.Error()
+	if e.TraceID != "" {
+		msg = fmt.Sprintf("%s (traceID: %s)", msg, e.TraceID)
+	}
+	if e.RequestBody != "" {
+		msg = fmt.Sprintf("%s (requestBody: %s)", msg, e.RequestBody)
+	}
+	return msg
+}
+
+func (e *APIError) Unwrap() error {
+	return e.Err
+}
+
+// TraceIDFromError returns the API trace ID from err if it is or wraps an APIError.
+// Use this when handling failures to log or display the trace ID for support.
+func TraceIDFromError(err error) string {
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.TraceID
+	}
+	return ""
+}
+
+// RequestBodyFromError returns the GraphQL request body from err if it is or wraps an APIError.
+func RequestBodyFromError(err error) string {
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.RequestBody
+	}
+	return ""
+}

--- a/gql_do_trace.go
+++ b/gql_do_trace.go
@@ -1,0 +1,172 @@
+package cato_go_sdk
+
+//Implements the same flow as gqlgenc’s do (including gzip), runs the same parse/unmarshal logic as parseResponse / unmarshal, reads Trace_id (with fallbacks for canonical / trace-id style names), and on any parse-time error with a non-empty trace wraps it in APIError
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/Yamashou/gqlgenc/clientv2"
+	"github.com/Yamashou/gqlgenc/graphqljson"
+)
+
+// traceIDFromResponseHeader returns the server tracing ID from response headers.
+// The Cato server sets "Trace_id" (see AbstractTracingPlugin#addTraceIdToResponse).
+func traceIDFromResponseHeader(h http.Header) string {
+	for _, key := range []string{"Trace_id", "Trace-Id"} {
+		if v := h.Get(key); v != "" {
+			return v
+		}
+	}
+	for k, vv := range h {
+		if strings.EqualFold(strings.ReplaceAll(k, "-", "_"), "trace_id") && len(vv) > 0 {
+			return vv[0]
+		}
+	}
+	return ""
+}
+
+// executeGQLWithTrace performs the GraphQL HTTP round trip like clientv2.Client.do,
+// then attaches Trace_id from the response to any returned error.
+func executeGQLWithTrace(_ context.Context, gqlc *clientv2.Client, req *http.Request, _ *clientv2.GQLRequestInfo, res any) error {
+	requestBody := requestBodyForError(req)
+
+	resp, err := gqlc.Client.Do(req)
+	if err != nil {
+		return &APIError{
+			Err:         fmt.Errorf("request failed: %w", err),
+			RequestBody: requestBody,
+		}
+	}
+	defer resp.Body.Close()
+
+	traceID := traceIDFromResponseHeader(resp.Header)
+
+	bodyReader := io.Reader(resp.Body)
+	if resp.Header.Get("Content-Encoding") == "gzip" {
+		gr, gerr := gzip.NewReader(resp.Body)
+		if gerr != nil {
+			return fmt.Errorf("gzip decode failed: %w", gerr)
+		}
+		defer gr.Close()
+		bodyReader = gr
+	}
+
+	body, err := io.ReadAll(bodyReader)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	parseErr := parseGQLResponse(gqlc, body, resp.StatusCode, res)
+	if parseErr == nil {
+		return parseErr
+	}
+
+	var api *APIError
+	if errors.As(parseErr, &api) && (api.TraceID != "" || api.RequestBody != "") {
+		return parseErr
+	}
+
+	return &APIError{
+		Err:         parseErr,
+		TraceID:     traceID,
+		RequestBody: requestBody,
+	}
+}
+
+// gqlEnvelope mirrors clientv2.response.
+type gqlEnvelope struct {
+	Data   json.RawMessage `json:"data"`
+	Errors json.RawMessage `json:"errors"`
+}
+
+func parseGQLResponse(gqlc *clientv2.Client, body []byte, httpCode int, result any) error {
+	errResponse := &clientv2.ErrorResponse{}
+	notOK := httpCode < 200 || 299 < httpCode
+	if notOK {
+		errResponse.NetworkError = &clientv2.HTTPError{
+			Code:    httpCode,
+			Message: fmt.Sprintf("Response body %s", string(body)),
+		}
+	}
+
+	if err := gqlUnmarshalResponse(gqlc, body, result); err != nil {
+		var gqlErr *clientv2.GqlErrorList
+		if errors.As(err, &gqlErr) {
+			errResponse.GqlErrors = &gqlErr.Errors
+		} else if !notOK {
+			return err
+		}
+	}
+
+	if errResponse.HasErrors() {
+		return errResponse
+	}
+
+	return nil
+}
+
+func gqlUnmarshalResponse(gqlc *clientv2.Client, data []byte, res any) error {
+	resp := gqlEnvelope{}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return fmt.Errorf("failed to decode data %s: %w", string(data), err)
+	}
+
+	var err error
+	if len(resp.Errors) > 0 {
+		err = &clientv2.GqlErrorList{}
+		if e := json.Unmarshal(data, err); e != nil {
+			return fmt.Errorf("faild to parse graphql errors. Response content %s - %w", string(data), e)
+		}
+		if !gqlc.ParseDataWhenErrors {
+			return err
+		}
+	}
+
+	if errData := graphqljson.UnmarshalData(resp.Data, res); errData != nil {
+		if gqlc.ParseDataWhenErrors {
+			return err
+		}
+		return fmt.Errorf("failed to decode data into response %s: %w", string(data), errData)
+	}
+
+	return err
+}
+
+func requestBodyForError(req *http.Request) string {
+	if req == nil {
+		return ""
+	}
+
+	if req.GetBody != nil {
+		rc, err := req.GetBody()
+		if err != nil {
+			return ""
+		}
+		defer rc.Close()
+
+		b, err := io.ReadAll(rc)
+		if err != nil {
+			return ""
+		}
+		return string(b)
+	}
+
+	if req.Body == nil {
+		return ""
+	}
+
+	b, err := io.ReadAll(req.Body)
+	if err != nil {
+		return ""
+	}
+	req.Body = io.NopCloser(bytes.NewReader(b))
+	return string(b)
+}

--- a/gql_do_trace_test.go
+++ b/gql_do_trace_test.go
@@ -1,0 +1,43 @@
+package cato_go_sdk
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestTraceIDFromResponseHeader(t *testing.T) {
+	t.Parallel()
+	h := http.Header{}
+	h.Set("Trace_id", "abc-123")
+	if got := traceIDFromResponseHeader(h); got != "abc-123" {
+		t.Fatalf("Trace_id: got %q", got)
+	}
+
+	h2 := http.Header{}
+	h2.Set("trace-id", "lower-456")
+	if got := traceIDFromResponseHeader(h2); got != "lower-456" {
+		t.Fatalf("trace-id alias: got %q", got)
+	}
+}
+
+func TestAPIErrorIncludesRequestBody(t *testing.T) {
+	t.Parallel()
+	err := &APIError{
+		Err:         errors.New("boom"),
+		TraceID:     "trace-1",
+		RequestBody: `{"query":"q","variables":{"id":"1"}}`,
+	}
+
+	msg := err.Error()
+	if !strings.Contains(msg, "traceID: trace-1") {
+		t.Fatalf("missing trace ID in message: %q", msg)
+	}
+	if !strings.Contains(msg, `requestBody: {"query":"q","variables":{"id":"1"}}`) {
+		t.Fatalf("missing request body in message: %q", msg)
+	}
+	if got := RequestBodyFromError(err); got != `{"query":"q","variables":{"id":"1"}}` {
+		t.Fatalf("unexpected request body from helper: %q", got)
+	}
+}


### PR DESCRIPTION
Tested with the latest cato terraform provider for few error and success cases.