### PR TITLE
fix: case-insensitive SocketInterfaceWanRole unmarshaling

### DIFF
--- a/.gqlgenc.yml
+++ b/.gqlgenc.yml
@@ -19,6 +19,8 @@ models:
     model: github.com/catonetworks/cato-go-sdk/scalars.Long
   OperationalStatus:
     model: github.com/catonetworks/cato-go-sdk/scalars.OperationalStatus
+  SocketInterfaceWanRole:
+    model: github.com/catonetworks/cato-go-sdk/scalars.SocketInterfaceWanRole
   Port:
     model: github.com/catonetworks/cato-go-sdk/scalars.Port
   Time:

--- a/models/models.go
+++ b/models/models.go
@@ -6348,14 +6348,14 @@ type IntegrationRefInput struct {
 
 // Basic Socket Interface configuration information
 type InterfaceInfo struct {
-	DestType                         *string                 `json:"destType,omitempty"`
-	DownstreamBandwidth              *int64                  `json:"downstreamBandwidth,omitempty"`
-	DownstreamBandwidthMbpsPrecision *float64                `json:"downstreamBandwidthMbpsPrecision,omitempty"`
-	ID                               string                  `json:"id"`
-	Name                             *string                 `json:"name,omitempty"`
-	UpstreamBandwidth                *int64                  `json:"upstreamBandwidth,omitempty"`
-	UpstreamBandwidthMbpsPrecision   *float64                `json:"upstreamBandwidthMbpsPrecision,omitempty"`
-	WanRole                          *SocketInterfaceWanRole `json:"wanRole,omitempty"`
+	DestType                         *string                         `json:"destType,omitempty"`
+	DownstreamBandwidth              *int64                          `json:"downstreamBandwidth,omitempty"`
+	DownstreamBandwidthMbpsPrecision *float64                        `json:"downstreamBandwidthMbpsPrecision,omitempty"`
+	ID                               string                          `json:"id"`
+	Name                             *string                         `json:"name,omitempty"`
+	UpstreamBandwidth                *int64                          `json:"upstreamBandwidth,omitempty"`
+	UpstreamBandwidthMbpsPrecision   *float64                        `json:"upstreamBandwidthMbpsPrecision,omitempty"`
+	WanRole                          *scalars.SocketInterfaceWanRole `json:"wanRole,omitempty"`
 }
 
 type InterfaceLinkState struct {
@@ -28304,67 +28304,6 @@ func (e *SocketInterfaceRole) UnmarshalJSON(b []byte) error {
 }
 
 func (e SocketInterfaceRole) MarshalJSON() ([]byte, error) {
-	var buf bytes.Buffer
-	e.MarshalGQL(&buf)
-	return buf.Bytes(), nil
-}
-
-type SocketInterfaceWanRole string
-
-const (
-	SocketInterfaceWanRoleNone SocketInterfaceWanRole = "NONE"
-	SocketInterfaceWanRoleWan1 SocketInterfaceWanRole = "WAN_1"
-	SocketInterfaceWanRoleWan2 SocketInterfaceWanRole = "WAN_2"
-	SocketInterfaceWanRoleWan3 SocketInterfaceWanRole = "WAN_3"
-	SocketInterfaceWanRoleWan4 SocketInterfaceWanRole = "WAN_4"
-)
-
-var AllSocketInterfaceWanRole = []SocketInterfaceWanRole{
-	SocketInterfaceWanRoleNone,
-	SocketInterfaceWanRoleWan1,
-	SocketInterfaceWanRoleWan2,
-	SocketInterfaceWanRoleWan3,
-	SocketInterfaceWanRoleWan4,
-}
-
-func (e SocketInterfaceWanRole) IsValid() bool {
-	switch e {
-	case SocketInterfaceWanRoleNone, SocketInterfaceWanRoleWan1, SocketInterfaceWanRoleWan2, SocketInterfaceWanRoleWan3, SocketInterfaceWanRoleWan4:
-		return true
-	}
-	return false
-}
-
-func (e SocketInterfaceWanRole) String() string {
-	return string(e)
-}
-
-func (e *SocketInterfaceWanRole) UnmarshalGQL(v any) error {
-	str, ok := v.(string)
-	if !ok {
-		return fmt.Errorf("enums must be strings")
-	}
-
-	*e = SocketInterfaceWanRole(str)
-	if !e.IsValid() {
-		return fmt.Errorf("%s is not a valid SocketInterfaceWanRole", str)
-	}
-	return nil
-}
-
-func (e SocketInterfaceWanRole) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
-}
-
-func (e *SocketInterfaceWanRole) UnmarshalJSON(b []byte) error {
-	s, err := strconv.Unquote(string(b))
-	if err != nil {
-		return err
-	}
-	return e.UnmarshalGQL(s)
-}
-
-func (e SocketInterfaceWanRole) MarshalJSON() ([]byte, error) {
 	var buf bytes.Buffer
 	e.MarshalGQL(&buf)
 	return buf.Bytes(), nil

--- a/scalars/socket_interface_wan_role.go
+++ b/scalars/socket_interface_wan_role.go
@@ -1,0 +1,67 @@
+package scalars
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+// SocketInterfaceWanRole is a case-insensitive enum for socket interface WAN roles.
+// Some backend environments return lowercase values (e.g. "wan_1") while the canonical
+// schema uses uppercase (e.g. "WAN_1"). Normalizing to uppercase on unmarshal handles both.
+type SocketInterfaceWanRole string
+
+const (
+	SocketInterfaceWanRoleNone SocketInterfaceWanRole = "NONE"
+	SocketInterfaceWanRoleWan1 SocketInterfaceWanRole = "WAN_1"
+	SocketInterfaceWanRoleWan2 SocketInterfaceWanRole = "WAN_2"
+	SocketInterfaceWanRoleWan3 SocketInterfaceWanRole = "WAN_3"
+	SocketInterfaceWanRoleWan4 SocketInterfaceWanRole = "WAN_4"
+)
+
+var validSocketInterfaceWanRoles = map[SocketInterfaceWanRole]struct{}{
+	SocketInterfaceWanRoleNone: {},
+	SocketInterfaceWanRoleWan1: {},
+	SocketInterfaceWanRoleWan2: {},
+	SocketInterfaceWanRoleWan3: {},
+	SocketInterfaceWanRoleWan4: {},
+}
+
+func (e SocketInterfaceWanRole) IsValid() bool {
+	_, ok := validSocketInterfaceWanRoles[e]
+	return ok
+}
+
+func (e SocketInterfaceWanRole) String() string {
+	return string(e)
+}
+
+func (e *SocketInterfaceWanRole) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("SocketInterfaceWanRole must be a string")
+	}
+	normalized := SocketInterfaceWanRole(strings.ToUpper(str))
+	if !normalized.IsValid() {
+		return fmt.Errorf("%q is not a valid SocketInterfaceWanRole", str)
+	}
+	*e = normalized
+	return nil
+}
+
+func (e SocketInterfaceWanRole) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(string(e)))
+}
+
+func (e *SocketInterfaceWanRole) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e SocketInterfaceWanRole) MarshalJSON() ([]byte, error) {
+	return []byte(strconv.Quote(string(e))), nil
+}


### PR DESCRIPTION
Some backend environments return lowercase wan role values (e.g. "wan_1") while the canonical schema uses uppercase ("WAN_1"). Move SocketInterfaceWanRole from generated models to a hand-written scalar that normalises the input to uppercase on unmarshal, accepting both cases without schema violation errors.