### PR TITLE
Update generated SDK schema

### DIFF
--- a/cato_api.graphqls
+++ b/cato_api.graphqls
@@ -939,6 +939,7 @@ type ApplicationControlFileRule {
   application: ApplicationControlApplication!
   applicationActivity: [ApplicationControlActivity!]!
   applicationActivitySatisfy: ApplicationControlSatisfy!
+  applicationContext: ApplicationControlContext!
   applicationCriteria: ApplicationControlCriteria!
   applicationCriteriaSatisfy: ApplicationControlSatisfy!
   device: [DeviceProfileRef!]!
@@ -4404,6 +4405,7 @@ type PolicySectionInfo {
 
 type PolicySectionMutationPayload {
   errors: [PolicyMutationError!]!
+  revision: PolicyRevision
   section: PolicySectionPayload
   status: PolicyMutationStatus!
 }
@@ -4411,6 +4413,7 @@ type PolicySectionMutationPayload {
 type PolicySectionPayload {
   access: EntityAccess
   audit: PolicyElementAudit!
+  metadata: PolicyElementMetadata
   properties: [PolicyElementPropertiesEnum!]!
   section: PolicySectionInfo!
 }
@@ -7948,7 +7951,7 @@ input ApplicationControlAddRuleDataInput {
   dataRule: ApplicationControlDataRuleInput = {application:{applicationType:[]},applicationContext:{applicationTenant:[]},applicationActivitySatisfy:ANY,applicationActivity:[],accessMethod:[],source:{country:[],host:[],site:[],subnet:[],ip:[],ipRange:[],globalIpRange:[],networkInterface:[],siteNetworkSubnet:[],floatingSubnet:[],user:[],usersGroup:[],group:[],systemGroup:[]},device:[],action:BLOCK,tracking:{event:{enabled:false},alert:{enabled:false,frequency:HOURLY,subscriptionGroup:[],webhook:[],mailingList:[]}},schedule:{activeOn:ALWAYS},severity:HIGH,fileAttributeSatisfy:ANY,fileAttribute:[],dlpProfile:{contentProfile:[],edmProfile:[]},applicationCriteriaSatisfy:ANY,applicationCriteria:{attributes:{complianceAttributes:{iso27001:ANY,sox:ANY,hippa:ANY,soc1:ANY,soc2:ANY,soc3:ANY,isae3402:ANY,pciDss:ANY},securityAttributes:{mfa:ANY,encryptionAtRest:ANY,auditTrail:ANY,rbac:ANY,rememberPassword:ANY,sso:ANY,trustedCertificate:ANY,tlsEnforcement:ANY,httpSecurityHeaders:ANY}},originCountry:[],risk:[]},actionConfig:{userNotification:[]}}
   description: String! = ""
   enabled: Boolean!
-  fileRule: ApplicationControlFileRuleInput = {application:{applicationType:[]},applicationActivitySatisfy:ANY,applicationActivity:[],accessMethod:[],source:{country:[],host:[],site:[],subnet:[],ip:[],ipRange:[],globalIpRange:[],networkInterface:[],siteNetworkSubnet:[],floatingSubnet:[],user:[],usersGroup:[],group:[],systemGroup:[]},device:[],action:BLOCK,tracking:{event:{enabled:false},alert:{enabled:false,frequency:HOURLY,subscriptionGroup:[],webhook:[],mailingList:[]}},schedule:{activeOn:ALWAYS},severity:HIGH,fileAttributeSatisfy:ANY,fileAttribute:[],applicationCriteriaSatisfy:ANY,applicationCriteria:{attributes:{complianceAttributes:{iso27001:ANY,sox:ANY,hippa:ANY,soc1:ANY,soc2:ANY,soc3:ANY,isae3402:ANY,pciDss:ANY},securityAttributes:{mfa:ANY,encryptionAtRest:ANY,auditTrail:ANY,rbac:ANY,rememberPassword:ANY,sso:ANY,trustedCertificate:ANY,tlsEnforcement:ANY,httpSecurityHeaders:ANY}},originCountry:[],risk:[]},actionConfig:{userNotification:[]}}
+  fileRule: ApplicationControlFileRuleInput = {application:{applicationType:[]},applicationContext:{applicationTenant:[]},applicationActivitySatisfy:ANY,applicationActivity:[],accessMethod:[],source:{country:[],host:[],site:[],subnet:[],ip:[],ipRange:[],globalIpRange:[],networkInterface:[],siteNetworkSubnet:[],floatingSubnet:[],user:[],usersGroup:[],group:[],systemGroup:[]},device:[],action:BLOCK,tracking:{event:{enabled:false},alert:{enabled:false,frequency:HOURLY,subscriptionGroup:[],webhook:[],mailingList:[]}},schedule:{activeOn:ALWAYS},severity:HIGH,fileAttributeSatisfy:ANY,fileAttribute:[],applicationCriteriaSatisfy:ANY,applicationCriteria:{attributes:{complianceAttributes:{iso27001:ANY,sox:ANY,hippa:ANY,soc1:ANY,soc2:ANY,soc3:ANY,isae3402:ANY,pciDss:ANY},securityAttributes:{mfa:ANY,encryptionAtRest:ANY,auditTrail:ANY,rbac:ANY,rememberPassword:ANY,sso:ANY,trustedCertificate:ANY,tlsEnforcement:ANY,httpSecurityHeaders:ANY}},originCountry:[],risk:[]},actionConfig:{userNotification:[]}}
   name: String!
   ruleType: ApplicationControlRuleType! = APPLICATION
 }
@@ -8157,6 +8160,7 @@ input ApplicationControlFileRuleInput {
   application: ApplicationControlApplicationInput! = {applicationType:[]}
   applicationActivity: [ApplicationControlActivityInput!]! = []
   applicationActivitySatisfy: ApplicationControlSatisfy! = ANY
+  applicationContext: ApplicationControlContextInput! = {applicationTenant:[]}
   applicationCriteria: ApplicationControlCriteriaInput! = {attributes:{complianceAttributes:{iso27001:ANY,sox:ANY,hippa:ANY,soc1:ANY,soc2:ANY,soc3:ANY,isae3402:ANY,pciDss:ANY},securityAttributes:{mfa:ANY,encryptionAtRest:ANY,auditTrail:ANY,rbac:ANY,rememberPassword:ANY,sso:ANY,trustedCertificate:ANY,tlsEnforcement:ANY,httpSecurityHeaders:ANY}},originCountry:[],risk:[]}
   applicationCriteriaSatisfy: ApplicationControlSatisfy! = ANY
   device: [DeviceProfileRefInput!]! = []
@@ -8176,6 +8180,7 @@ input ApplicationControlFileRuleUpdateInput {
   application: ApplicationControlApplicationUpdateInput
   applicationActivity: [ApplicationControlActivityInput!]
   applicationActivitySatisfy: ApplicationControlSatisfy
+  applicationContext: ApplicationControlContextUpdateInput
   applicationCriteria: ApplicationControlCriteriaUpdateInput
   applicationCriteriaSatisfy: ApplicationControlSatisfy
   device: [DeviceProfileRefInput!]
@@ -14968,6 +14973,7 @@ enum GroupMemberRefType {
   NETWORK_INTERFACE
   SITE
   SITE_NETWORK_SUBNET
+  VLAN
 }
 
 enum HaReadiness {
@@ -15604,6 +15610,8 @@ enum PolicyRuleTypeEnum {
   POLICY_RULE
   """ Indicate the rule is a scoping context for sub policy """
   SUB_POLICY_SCOPE
+  """ Indicate the rule is a nested rule under a parent rule (e.g. a firewall exception) """
+  SUB_RULE
 }
 
 enum PolicySectionPositionEnum {

--- a/models/models.go
+++ b/models/models.go
@@ -2391,6 +2391,7 @@ type ApplicationControlFileRule struct {
 	Application                *ApplicationControlApplication     `json:"application"`
 	ApplicationActivity        []*ApplicationControlActivity      `json:"applicationActivity"`
 	ApplicationActivitySatisfy ApplicationControlSatisfy          `json:"applicationActivitySatisfy"`
+	ApplicationContext         *ApplicationControlContext         `json:"applicationContext"`
 	ApplicationCriteria        *ApplicationControlCriteria        `json:"applicationCriteria"`
 	ApplicationCriteriaSatisfy ApplicationControlSatisfy          `json:"applicationCriteriaSatisfy"`
 	Device                     []*DeviceProfileRef                `json:"device"`
@@ -2410,6 +2411,7 @@ type ApplicationControlFileRuleInput struct {
 	Application                *ApplicationControlApplicationInput     `json:"application"`
 	ApplicationActivity        []*ApplicationControlActivityInput      `json:"applicationActivity"`
 	ApplicationActivitySatisfy ApplicationControlSatisfy               `json:"applicationActivitySatisfy"`
+	ApplicationContext         *ApplicationControlContextInput         `json:"applicationContext"`
 	ApplicationCriteria        *ApplicationControlCriteriaInput        `json:"applicationCriteria"`
 	ApplicationCriteriaSatisfy ApplicationControlSatisfy               `json:"applicationCriteriaSatisfy"`
 	Device                     []*DeviceProfileRefInput                `json:"device"`
@@ -2429,6 +2431,7 @@ type ApplicationControlFileRuleUpdateInput struct {
 	Application                *ApplicationControlApplicationUpdateInput  `json:"application,omitempty"`
 	ApplicationActivity        []*ApplicationControlActivityInput         `json:"applicationActivity,omitempty"`
 	ApplicationActivitySatisfy *ApplicationControlSatisfy                 `json:"applicationActivitySatisfy,omitempty"`
+	ApplicationContext         *ApplicationControlContextUpdateInput      `json:"applicationContext,omitempty"`
 	ApplicationCriteria        *ApplicationControlCriteriaUpdateInput     `json:"applicationCriteria,omitempty"`
 	ApplicationCriteriaSatisfy *ApplicationControlSatisfy                 `json:"applicationCriteriaSatisfy,omitempty"`
 	Device                     []*DeviceProfileRefInput                   `json:"device,omitempty"`
@@ -9277,14 +9280,16 @@ type PolicySectionInfo struct {
 }
 
 type PolicySectionMutationPayload struct {
-	Errors  []*PolicyMutationError `json:"errors"`
-	Section *PolicySectionPayload  `json:"section,omitempty"`
-	Status  PolicyMutationStatus   `json:"status"`
+	Errors   []*PolicyMutationError `json:"errors"`
+	Revision *PolicyRevision        `json:"revision,omitempty"`
+	Section  *PolicySectionPayload  `json:"section,omitempty"`
+	Status   PolicyMutationStatus   `json:"status"`
 }
 
 type PolicySectionPayload struct {
 	Access     *EntityAccess                 `json:"access,omitempty"`
 	Audit      *PolicyElementAudit           `json:"audit"`
+	Metadata   *PolicyElementMetadata        `json:"metadata,omitempty"`
 	Properties []PolicyElementPropertiesEnum `json:"properties"`
 	Section    *PolicySectionInfo            `json:"section"`
 }
@@ -23574,6 +23579,7 @@ const (
 	GroupMemberRefTypeNetworkInterface  GroupMemberRefType = "NETWORK_INTERFACE"
 	GroupMemberRefTypeSite              GroupMemberRefType = "SITE"
 	GroupMemberRefTypeSiteNetworkSubnet GroupMemberRefType = "SITE_NETWORK_SUBNET"
+	GroupMemberRefTypeVlan              GroupMemberRefType = "VLAN"
 )
 
 var AllGroupMemberRefType = []GroupMemberRefType{
@@ -23584,11 +23590,12 @@ var AllGroupMemberRefType = []GroupMemberRefType{
 	GroupMemberRefTypeNetworkInterface,
 	GroupMemberRefTypeSite,
 	GroupMemberRefTypeSiteNetworkSubnet,
+	GroupMemberRefTypeVlan,
 }
 
 func (e GroupMemberRefType) IsValid() bool {
 	switch e {
-	case GroupMemberRefTypeDevice, GroupMemberRefTypeFloatingSubnet, GroupMemberRefTypeGlobalIPRange, GroupMemberRefTypeHost, GroupMemberRefTypeNetworkInterface, GroupMemberRefTypeSite, GroupMemberRefTypeSiteNetworkSubnet:
+	case GroupMemberRefTypeDevice, GroupMemberRefTypeFloatingSubnet, GroupMemberRefTypeGlobalIPRange, GroupMemberRefTypeHost, GroupMemberRefTypeNetworkInterface, GroupMemberRefTypeSite, GroupMemberRefTypeSiteNetworkSubnet, GroupMemberRefTypeVlan:
 		return true
 	}
 	return false
@@ -26632,16 +26639,19 @@ const (
 	PolicyRuleTypeEnumPolicyRule PolicyRuleTypeEnum = "POLICY_RULE"
 	//  Indicate the rule is a scoping context for sub policy
 	PolicyRuleTypeEnumSubPolicyScope PolicyRuleTypeEnum = "SUB_POLICY_SCOPE"
+	//  Indicate the rule is a nested rule under a parent rule (e.g. a firewall exception)
+	PolicyRuleTypeEnumSubRule PolicyRuleTypeEnum = "SUB_RULE"
 )
 
 var AllPolicyRuleTypeEnum = []PolicyRuleTypeEnum{
 	PolicyRuleTypeEnumPolicyRule,
 	PolicyRuleTypeEnumSubPolicyScope,
+	PolicyRuleTypeEnumSubRule,
 }
 
 func (e PolicyRuleTypeEnum) IsValid() bool {
 	switch e {
-	case PolicyRuleTypeEnumPolicyRule, PolicyRuleTypeEnumSubPolicyScope:
+	case PolicyRuleTypeEnumPolicyRule, PolicyRuleTypeEnumSubPolicyScope, PolicyRuleTypeEnumSubRule:
 		return true
 	}
 	return false


### PR DESCRIPTION
## Summary
- Refreshes cato_api.graphqls from the upstream Cato schema endpoint.
- Applies and validates schema patches, deleting patch files that upstream now includes.
- Regenerates the Go SDK client/models and verifies `go build ./...`.

## Test plan
- `bash scripts/schema_update_ci.sh`
