### PR TITLE
Update generated SDK schema

### DIFF
--- a/cato_api.graphqls
+++ b/cato_api.graphqls
@@ -31,8 +31,8 @@ type Query {
   accountSnapshot(accountID: ID, id: ID @deprecated(reason: "by accountID")): AccountSnapshot @ga
   admin(accountId: ID!, adminID: ID!): GetAdminPayload @ga
   admins(accountID: ID!, limit: Int = 50, from: Int = 0, search: String = "", sort: [SortInput], adminIDs: [ID!]): AdminsResult @ga
-  appStats(accountID: ID!, timeFrame: TimeFrame!, measures: [Measure], dimensions: [Dimension], filters: [AppStatsFilter!], postAggFilters: [AppStatsPostAggFilter!], sort: [AppStatsSort!]): AppStats @ga
-  appStatsTimeSeries(accountID: ID!, timeFrame: TimeFrame!, measures: [Measure], dimensions: [Dimension], filters: [AppStatsFilter!]): AppStatsTimeSeries @ga
+  appStats(accountID: ID!, timeFrame: TimeFrame!, measures: [Measure], dimensions: [Dimension], filters: [AppStatsFilter!], postAggFilters: [AppStatsPostAggFilter!], sort: [AppStatsSort!], includeEmptyDimension: Boolean): AppStats @ga
+  appStatsTimeSeries(accountID: ID!, timeFrame: TimeFrame!, measures: [Measure], dimensions: [Dimension], filters: [AppStatsFilter!], includeEmptyDimension: Boolean): AppStatsTimeSeries @ga
   auditFeed(accountIDs: [ID!], ids: [ID!] @deprecated(reason: "by accountIDs"), timeFrame: TimeFrame!, filters: [AuditFieldFilterInput!], marker: String): AuditFeed @ga
   businessPlatform(accountId: ID!): BusinessPlatformQueries @rollout
   catalogs(accountId: ID!): CatalogQueries
@@ -42,9 +42,9 @@ type Query {
   devices(accountId: ID!): DevicesQueries! @beta
   enterpriseDirectory(accountId: ID!): EnterpriseDirectoryQueries
   entityLookup(accountID: ID!, type: EntityType!, limit: Int = 50, from: Int = 0, parent: EntityInput, search: String = "", entityIDs: [ID!], sort: [SortInput], filters: [LookupFilterInput], helperFields: [String!]): EntityLookupResult! @ga
-  events(accountID: ID!, timeFrame: TimeFrame!, measures: [EventsMeasure], dimensions: [EventsDimension], filters: [EventsFilter!], postAggFilters: [EventsPostAggFilter!], sort: [EventsSort!]): Events @ga
+  events(accountID: ID!, timeFrame: TimeFrame!, measures: [EventsMeasure], dimensions: [EventsDimension], filters: [EventsFilter!], postAggFilters: [EventsPostAggFilter!], sort: [EventsSort!], includeEmptyDimension: Boolean): Events @ga
   eventsFeed(accountIDs: [ID!], filters: [EventFeedFieldFilterInput!], marker: String): EventsFeedData @ga
-  eventsTimeSeries(accountID: ID!, timeFrame: TimeFrame!, measures: [EventsMeasure], dimensions: [EventsDimension], filters: [EventsFilter!]): EventsTimeSeries @ga
+  eventsTimeSeries(accountID: ID!, timeFrame: TimeFrame!, measures: [EventsMeasure], dimensions: [EventsDimension], filters: [EventsFilter!], includeEmptyDimension: Boolean): EventsTimeSeries @ga
   externalAccess(accountId: ID!): ExternalAccessQueries!
   groups(accountId: ID!): GroupsQueries
   hardware(accountId: ID!): HardwareQueries
@@ -5513,12 +5513,14 @@ type SocketBypassRule implements IPolicyRule {
 
 type SocketBypassRuleMutationPayload implements IPolicyRuleMutationPayload {
   errors: [PolicyMutationError!]!
+  revision: PolicyRevision
   rule: SocketBypassRulePayload
   status: PolicyMutationStatus!
 }
 
 type SocketBypassRulePayload implements IPolicyRulePayload {
   audit: PolicyElementAudit!
+  metadata: PolicyElementMetadata
   properties: [PolicyElementPropertiesEnum!]!
   rule: SocketBypassRule!
 }
@@ -5674,12 +5676,14 @@ type SocketLanFirewallRule implements IPolicyRule {
 
 type SocketLanFirewallRuleMutationPayload implements IPolicyRuleMutationPayload {
   errors: [PolicyMutationError!]!
+  revision: PolicyRevision
   rule: SocketLanFirewallRulePayload
   status: PolicyMutationStatus!
 }
 
 type SocketLanFirewallRulePayload implements IPolicyRulePayload {
   audit: PolicyElementAudit!
+  metadata: PolicyElementMetadata
   properties: [PolicyElementPropertiesEnum!]!
   rule: SocketLanFirewallRule!
 }
@@ -5773,12 +5777,14 @@ type SocketLanRule implements IPolicyRule {
 
 type SocketLanRuleMutationPayload implements IPolicyRuleMutationPayload {
   errors: [PolicyMutationError!]!
+  revision: PolicyRevision
   rule: SocketLanRulePayload
   status: PolicyMutationStatus!
 }
 
 type SocketLanRulePayload implements IPolicyRulePayload {
   audit: PolicyElementAudit!
+  metadata: PolicyElementMetadata
   properties: [PolicyElementPropertiesEnum!]!
   rule: SocketLanRule!
 }
@@ -7090,12 +7096,14 @@ type WanNetworkRuleException {
 
 type WanNetworkRuleMutationPayload implements IPolicyRuleMutationPayload {
   errors: [PolicyMutationError!]!
+  revision: PolicyRevision
   rule: WanNetworkRulePayload
   status: PolicyMutationStatus!
 }
 
 type WanNetworkRulePayload implements IPolicyRulePayload {
   audit: PolicyElementAudit!
+  metadata: PolicyElementMetadata
   properties: [PolicyElementPropertiesEnum!]!
   rule: WanNetworkRule!
 }
@@ -7373,6 +7381,7 @@ type ZtnaAppConnector {
   privateAppRef: [PrivateApplicationRef!]!
   serialNumber: String
   socketId: ID
+  socketInfo: ZtnaAppConnectorSocketInfo
   socketModel: SocketModel
   type: ZtnaAppConnectorType!
 }
@@ -7551,6 +7560,15 @@ type ZtnaAppConnectorSnapshotSummaryPayload {
 type ZtnaAppConnectorSnapshotVersionSummaryItem {
   total: Int!
   version: String!
+}
+
+""" Socket runtime/version info for an assigned App Connector. Null when no socket is assigned. """
+type ZtnaAppConnectorSocketInfo {
+  rollbackEligibleUntil: DateTime
+  rollbackTargetVersion: String
+  upgradesPaused: Boolean!
+  version: String
+  versionUpdateTime: DateTime
 }
 
 type ZtnaAppConnectorUpgradeInfo {
@@ -9437,6 +9455,13 @@ input DynamicIpAllocationUpdateRuleInput {
   rule: DynamicIpAllocationUpdateRuleDataInput!
 }
 
+input EmailFilterInput {
+  eq: Email
+  in: [Email!]
+  neq: Email
+  nin: [Email!]
+}
+
 input EnableServiceForManagedAccountInput {
   managedAccountId: ID!
   service: LicenseSku!
@@ -10412,7 +10437,10 @@ input PopLocationAllocateIpInput {
   type: PopLocationAllocatedIpType! = BYOIP
 }
 
-""" Filter options for querying allocated IP addresses for PoP locations. """
+"""
+a
+Filter options for querying allocated IP addresses for PoP locations.
+"""
 input PopLocationAllocatedIpFilterInput {
   account: StringFilterInput
   allocatedIp: StringFilterInput
@@ -12504,12 +12532,13 @@ input UploadFileInput {
 input UserFilterInput {
   department: [StringFilterInput!]
   directoryId: [StringFilterInput!]
+  email: [EmailFilterInput!]
+  id: [IdFilterInput!] @ea
   importType: [ImportTypeFilterInput!]
   jobTitle: [StringFilterInput!]
   remoteAccessEligibility: [BooleanFilterInput!]
   riskScore: [RiskScoreFilterInput!]
   searchTerm: FreeTextFilterInput
-  userId: [IdFilterInput!] @ea
   userStatus: [UserStatusFilterInput!]
 }
 
@@ -14463,7 +14492,7 @@ enum EventFieldName {
   ai_app_risk_level
   """ AI Proxy rule name. CMA Name: AI Proxy Rule Name """
   ai_proxy_rule_name
-  """ AI Findings reason text from the feed. CMA Name: Ai Reason """
+  """ AI Findings reason text from the feed. CMA Name: AI Reason """
   ai_reason
   """ A unique identifier of the alert notification. CMA Name: Alert id """
   alert_id
@@ -14680,6 +14709,8 @@ enum EventFieldName {
   directory_sync_type
   """ If policy is set to disinfect, return the result of this action. CMA Name: Disinfect Result """
   disinfect_result
+  """ Display Name. CMA Name: Display Name """
+  display_name
   """ Describes the behavior when the DLP system encounters a failure. CMA Name: DLP Fail Mode """
   dlp_fail_mode
   """ DLP profiles related to the event. CMA Name: DLP Profiles """
@@ -14786,6 +14817,8 @@ enum EventFieldName {
   indicator
   """ The initial status of the object, before any policy was applied. CMA Name: Initial Object Status """
   initial_object_status
+  """ Inspection Mode. CMA Name: Inspection Mode """
+  inspection_mode
   """ Unique identifier for a single AI interaction between an application and an AI model. CMA Name: Interaction ID """
   interaction_id
   """ Inferred user intent of the AI interaction (e.g. Seek Advice, Generate Content, Get Information), as classified by the AI Security Engine. CMA Name: Interaction Intent """
@@ -14810,8 +14843,12 @@ enum EventFieldName {
   is_cloud_app
   """ Is Compliant. CMA Name: Is Compliant """
   is_compliant
+  """ Is Encrypted. CMA Name: Is Encrypted """
+  is_encrypted
   """ Is Managed. CMA Name: Is Managed """
   is_managed
+  """ Is Public. CMA Name: Is Public """
+  is_public
   """ Is the app for this event defined as a sanctioned app? (True/False). CMA Name: Is Sanctioned App """
   is_sanctioned_app
   """ If the events was part of the sinkhole flow. CMA Name: Is Sinkhole """
@@ -14822,6 +14859,10 @@ enum EventFieldName {
   key_name
   """ A list of labels providing additional context for the event. CMA Name: Labels """
   labels
+  """ Last Modified. CMA Name: Last Modified """
+  last_modified_at
+  """ Last Seen. CMA Name: Last Seen """
+  last_seen_at
   """ Role of the conversation participant for the analyzed turn (user, assistant, or tool call). CMA Name: Last Turn Role """
   last_turn_role
   """ Data that measures the congestion for a specific link. CMA Name: Link Health is Congested """
@@ -14838,6 +14879,8 @@ enum EventFieldName {
   logged_in_user
   """ Login action, values are: User portal (myvpn.catonetworks.com) or VPN client (Client or site traffic). CMA Name: Login Type """
   login_type
+  """ Matched count for each DLP data types found to the event. CMA Name: Matched Count """
+  matched_count
   """ Matched DLP data types related to the event. CMA Name: Matched Data Types """
   matched_data_types
   """ Unique identifier used to correlate request and response events for the same message. CMA Name: Message ID """
@@ -14946,6 +14989,8 @@ enum EventFieldName {
   rule_name
   """ Secondary socket serial number. CMA Name: Secondary Socket Serial """
   secondary_socket_serial @deprecated(reason: "use socket_serial instead. Planned end-of-life (EoL) date: April 1, 2026.")
+  """ Sensitivity Display Name. CMA Name: Sensitivity Display Name """
+  sensitivity_display_name
   """ Server IP address. CMA Name: Server IP """
   server_ip
   """ The TLS key exchange algorithm negotiated between the connecting client and the Cato PoP during TLS inspection. This is the algorithm used to establish the shared secret for encrypting traffic on the server-facing (inbound) side of the proxy. CMA Name: Server Key Exchange Algorithm """
@@ -14960,6 +15005,8 @@ enum EventFieldName {
   sharing_scope
   """ Sign In Types. CMA Name: Sign In Types """
   sign_in_event_types
+  """ Signal Source. CMA Name: Signal Source """
+  signal_source
   """ For IPS and SAM, ID of the IPS signature. CMA Name: Signature ID """
   signature_id
   """ Site web proxy instance ID. CMA Name: Site Web Proxy ID """
@@ -16592,9 +16639,17 @@ enum StoryStatusEnum {
 
 enum StoryVerdictEnum {
   Benign
+  ConfigurationIssue
+  FalsePositive
+  HardwareIssue
   Informational
+  InsufficientData
   Malicious
+  OverlayIssue
+  PlannedMaintenance
+  SelfRecovered
   Suspicious
+  UnderlayIssue
 }
 
 enum SubPolicyProperty {

--- a/models/models.go
+++ b/models/models.go
@@ -5534,6 +5534,13 @@ type DynamicIPAllocationUpdateRuleInput struct {
 	Rule *DynamicIPAllocationUpdateRuleDataInput `json:"rule"`
 }
 
+type EmailFilterInput struct {
+	Eq  *string  `json:"eq,omitempty"`
+	In  []string `json:"in,omitempty"`
+	Neq *string  `json:"neq,omitempty"`
+	Nin []string `json:"nin,omitempty"`
+}
+
 type EnableServiceForManagedAccountInput struct {
 	ManagedAccountID string     `json:"managedAccountId"`
 	Service          LicenseSku `json:"service"`
@@ -9564,6 +9571,7 @@ type PopLocationAllocatedIP struct {
 	Subnet         *string                      `json:"subnet,omitempty"`
 }
 
+// a
 // Filter options for querying allocated IP addresses for PoP locations.
 type PopLocationAllocatedIPFilterInput struct {
 	Account        *StringFilterInput                     `json:"account,omitempty"`
@@ -11437,9 +11445,10 @@ func (this SocketBypassRule) GetName() string                { return this.Name 
 func (this SocketBypassRule) GetSection() *PolicySectionInfo { return this.Section }
 
 type SocketBypassRuleMutationPayload struct {
-	Errors []*PolicyMutationError   `json:"errors"`
-	Rule   *SocketBypassRulePayload `json:"rule,omitempty"`
-	Status PolicyMutationStatus     `json:"status"`
+	Errors   []*PolicyMutationError   `json:"errors"`
+	Revision *PolicyRevision          `json:"revision,omitempty"`
+	Rule     *SocketBypassRulePayload `json:"rule,omitempty"`
+	Status   PolicyMutationStatus     `json:"status"`
 }
 
 func (SocketBypassRuleMutationPayload) IsIPolicyRuleMutationPayload() {}
@@ -11458,6 +11467,7 @@ func (this SocketBypassRuleMutationPayload) GetStatus() PolicyMutationStatus { r
 
 type SocketBypassRulePayload struct {
 	Audit      *PolicyElementAudit           `json:"audit"`
+	Metadata   *PolicyElementMetadata        `json:"metadata,omitempty"`
 	Properties []PolicyElementPropertiesEnum `json:"properties"`
 	Rule       *SocketBypassRule             `json:"rule"`
 }
@@ -11928,9 +11938,10 @@ func (this SocketLanFirewallRule) GetName() string                { return this.
 func (this SocketLanFirewallRule) GetSection() *PolicySectionInfo { return this.Section }
 
 type SocketLanFirewallRuleMutationPayload struct {
-	Errors []*PolicyMutationError        `json:"errors"`
-	Rule   *SocketLanFirewallRulePayload `json:"rule,omitempty"`
-	Status PolicyMutationStatus          `json:"status"`
+	Errors   []*PolicyMutationError        `json:"errors"`
+	Revision *PolicyRevision               `json:"revision,omitempty"`
+	Rule     *SocketLanFirewallRulePayload `json:"rule,omitempty"`
+	Status   PolicyMutationStatus          `json:"status"`
 }
 
 func (SocketLanFirewallRuleMutationPayload) IsIPolicyRuleMutationPayload() {}
@@ -11949,6 +11960,7 @@ func (this SocketLanFirewallRuleMutationPayload) GetStatus() PolicyMutationStatu
 
 type SocketLanFirewallRulePayload struct {
 	Audit      *PolicyElementAudit           `json:"audit"`
+	Metadata   *PolicyElementMetadata        `json:"metadata,omitempty"`
 	Properties []PolicyElementPropertiesEnum `json:"properties"`
 	Rule       *SocketLanFirewallRule        `json:"rule"`
 }
@@ -12202,9 +12214,10 @@ func (this SocketLanRule) GetName() string                { return this.Name }
 func (this SocketLanRule) GetSection() *PolicySectionInfo { return this.Section }
 
 type SocketLanRuleMutationPayload struct {
-	Errors []*PolicyMutationError `json:"errors"`
-	Rule   *SocketLanRulePayload  `json:"rule,omitempty"`
-	Status PolicyMutationStatus   `json:"status"`
+	Errors   []*PolicyMutationError `json:"errors"`
+	Revision *PolicyRevision        `json:"revision,omitempty"`
+	Rule     *SocketLanRulePayload  `json:"rule,omitempty"`
+	Status   PolicyMutationStatus   `json:"status"`
 }
 
 func (SocketLanRuleMutationPayload) IsIPolicyRuleMutationPayload() {}
@@ -12223,6 +12236,7 @@ func (this SocketLanRuleMutationPayload) GetStatus() PolicyMutationStatus { retu
 
 type SocketLanRulePayload struct {
 	Audit      *PolicyElementAudit           `json:"audit"`
+	Metadata   *PolicyElementMetadata        `json:"metadata,omitempty"`
 	Properties []PolicyElementPropertiesEnum `json:"properties"`
 	Rule       *SocketLanRule                `json:"rule"`
 }
@@ -14593,12 +14607,13 @@ type User struct {
 type UserFilterInput struct {
 	Department              []*StringFilterInput     `json:"department,omitempty"`
 	DirectoryID             []*StringFilterInput     `json:"directoryId,omitempty"`
+	Email                   []*EmailFilterInput      `json:"email,omitempty"`
+	ID                      []*IDFilterInput         `json:"id,omitempty"`
 	ImportType              []*ImportTypeFilterInput `json:"importType,omitempty"`
 	JobTitle                []*StringFilterInput     `json:"jobTitle,omitempty"`
 	RemoteAccessEligibility []*BooleanFilterInput    `json:"remoteAccessEligibility,omitempty"`
 	RiskScore               []*RiskScoreFilterInput  `json:"riskScore,omitempty"`
 	SearchTerm              *FreeTextFilterInput     `json:"searchTerm,omitempty"`
-	UserID                  []*IDFilterInput         `json:"userId,omitempty"`
 	UserStatus              []*UserStatusFilterInput `json:"userStatus,omitempty"`
 }
 
@@ -15650,9 +15665,10 @@ type WanNetworkRuleExceptionInput struct {
 }
 
 type WanNetworkRuleMutationPayload struct {
-	Errors []*PolicyMutationError `json:"errors"`
-	Rule   *WanNetworkRulePayload `json:"rule,omitempty"`
-	Status PolicyMutationStatus   `json:"status"`
+	Errors   []*PolicyMutationError `json:"errors"`
+	Revision *PolicyRevision        `json:"revision,omitempty"`
+	Rule     *WanNetworkRulePayload `json:"rule,omitempty"`
+	Status   PolicyMutationStatus   `json:"status"`
 }
 
 func (WanNetworkRuleMutationPayload) IsIPolicyRuleMutationPayload() {}
@@ -15671,6 +15687,7 @@ func (this WanNetworkRuleMutationPayload) GetStatus() PolicyMutationStatus { ret
 
 type WanNetworkRulePayload struct {
 	Audit      *PolicyElementAudit           `json:"audit"`
+	Metadata   *PolicyElementMetadata        `json:"metadata,omitempty"`
 	Properties []PolicyElementPropertiesEnum `json:"properties"`
 	Rule       *WanNetworkRule               `json:"rule"`
 }
@@ -16260,6 +16277,7 @@ type ZtnaAppConnector struct {
 	PrivateAppRef        []*PrivateApplicationRef              `json:"privateAppRef"`
 	SerialNumber         *string                               `json:"serialNumber,omitempty"`
 	SocketID             *string                               `json:"socketId,omitempty"`
+	SocketInfo           *ZtnaAppConnectorSocketInfo           `json:"socketInfo,omitempty"`
 	SocketModel          *SocketModel                          `json:"socketModel,omitempty"`
 	Type                 ZtnaAppConnectorType                  `json:"type"`
 }
@@ -16573,6 +16591,15 @@ type ZtnaAppConnectorSnapshotSummaryPayload struct {
 type ZtnaAppConnectorSnapshotVersionSummaryItem struct {
 	Total   int64  `json:"total"`
 	Version string `json:"version"`
+}
+
+// Socket runtime/version info for an assigned App Connector. Null when no socket is assigned.
+type ZtnaAppConnectorSocketInfo struct {
+	RollbackEligibleUntil *string `json:"rollbackEligibleUntil,omitempty"`
+	RollbackTargetVersion *string `json:"rollbackTargetVersion,omitempty"`
+	UpgradesPaused        bool    `json:"upgradesPaused"`
+	Version               *string `json:"version,omitempty"`
+	VersionUpdateTime     *string `json:"versionUpdateTime,omitempty"`
 }
 
 // Filter input for ZTNA App Connector type
@@ -22388,7 +22415,7 @@ const (
 	EventFieldNameAiAppRiskLevel EventFieldName = "ai_app_risk_level"
 	//  AI Proxy rule name. CMA Name: AI Proxy Rule Name
 	EventFieldNameAiProxyRuleName EventFieldName = "ai_proxy_rule_name"
-	//  AI Findings reason text from the feed. CMA Name: Ai Reason
+	//  AI Findings reason text from the feed. CMA Name: AI Reason
 	EventFieldNameAiReason EventFieldName = "ai_reason"
 	//  A unique identifier of the alert notification. CMA Name: Alert id
 	EventFieldNameAlertID EventFieldName = "alert_id"
@@ -22601,6 +22628,8 @@ const (
 	EventFieldNameDirectorySyncType EventFieldName = "directory_sync_type"
 	//  If policy is set to disinfect, return the result of this action. CMA Name: Disinfect Result
 	EventFieldNameDisinfectResult EventFieldName = "disinfect_result"
+	//  Display Name. CMA Name: Display Name
+	EventFieldNameDisplayName EventFieldName = "display_name"
 	//  Describes the behavior when the DLP system encounters a failure. CMA Name: DLP Fail Mode
 	EventFieldNameDlpFailMode EventFieldName = "dlp_fail_mode"
 	//  DLP profiles related to the event. CMA Name: DLP Profiles
@@ -22707,6 +22736,8 @@ const (
 	EventFieldNameIndicator EventFieldName = "indicator"
 	//  The initial status of the object, before any policy was applied. CMA Name: Initial Object Status
 	EventFieldNameInitialObjectStatus EventFieldName = "initial_object_status"
+	//  Inspection Mode. CMA Name: Inspection Mode
+	EventFieldNameInspectionMode EventFieldName = "inspection_mode"
 	//  Unique identifier for a single AI interaction between an application and an AI model. CMA Name: Interaction ID
 	EventFieldNameInteractionID EventFieldName = "interaction_id"
 	//  Inferred user intent of the AI interaction (e.g. Seek Advice, Generate Content, Get Information), as classified by the AI Security Engine. CMA Name: Interaction Intent
@@ -22731,8 +22762,12 @@ const (
 	EventFieldNameIsCloudApp EventFieldName = "is_cloud_app"
 	//  Is Compliant. CMA Name: Is Compliant
 	EventFieldNameIsCompliant EventFieldName = "is_compliant"
+	//  Is Encrypted. CMA Name: Is Encrypted
+	EventFieldNameIsEncrypted EventFieldName = "is_encrypted"
 	//  Is Managed. CMA Name: Is Managed
 	EventFieldNameIsManaged EventFieldName = "is_managed"
+	//  Is Public. CMA Name: Is Public
+	EventFieldNameIsPublic EventFieldName = "is_public"
 	//  Is the app for this event defined as a sanctioned app? (True/False). CMA Name: Is Sanctioned App
 	EventFieldNameIsSanctionedApp EventFieldName = "is_sanctioned_app"
 	//  If the events was part of the sinkhole flow. CMA Name: Is Sinkhole
@@ -22743,6 +22778,10 @@ const (
 	EventFieldNameKeyName EventFieldName = "key_name"
 	//  A list of labels providing additional context for the event. CMA Name: Labels
 	EventFieldNameLabels EventFieldName = "labels"
+	//  Last Modified. CMA Name: Last Modified
+	EventFieldNameLastModifiedAt EventFieldName = "last_modified_at"
+	//  Last Seen. CMA Name: Last Seen
+	EventFieldNameLastSeenAt EventFieldName = "last_seen_at"
 	//  Role of the conversation participant for the analyzed turn (user, assistant, or tool call). CMA Name: Last Turn Role
 	EventFieldNameLastTurnRole EventFieldName = "last_turn_role"
 	//  Data that measures the congestion for a specific link. CMA Name: Link Health is Congested
@@ -22759,6 +22798,8 @@ const (
 	EventFieldNameLoggedInUser EventFieldName = "logged_in_user"
 	//  Login action, values are: User portal (myvpn.catonetworks.com) or VPN client (Client or site traffic). CMA Name: Login Type
 	EventFieldNameLoginType EventFieldName = "login_type"
+	//  Matched count for each DLP data types found to the event. CMA Name: Matched Count
+	EventFieldNameMatchedCount EventFieldName = "matched_count"
 	//  Matched DLP data types related to the event. CMA Name: Matched Data Types
 	EventFieldNameMatchedDataTypes EventFieldName = "matched_data_types"
 	//  Unique identifier used to correlate request and response events for the same message. CMA Name: Message ID
@@ -22867,6 +22908,8 @@ const (
 	EventFieldNameRuleName EventFieldName = "rule_name"
 	//  Secondary socket serial number. CMA Name: Secondary Socket Serial
 	EventFieldNameSecondarySocketSerial EventFieldName = "secondary_socket_serial"
+	//  Sensitivity Display Name. CMA Name: Sensitivity Display Name
+	EventFieldNameSensitivityDisplayName EventFieldName = "sensitivity_display_name"
 	//  Server IP address. CMA Name: Server IP
 	EventFieldNameServerIP EventFieldName = "server_ip"
 	//  The TLS key exchange algorithm negotiated between the connecting client and the Cato PoP during TLS inspection. This is the algorithm used to establish the shared secret for encrypting traffic on the server-facing (inbound) side of the proxy. CMA Name: Server Key Exchange Algorithm
@@ -22881,6 +22924,8 @@ const (
 	EventFieldNameSharingScope EventFieldName = "sharing_scope"
 	//  Sign In Types. CMA Name: Sign In Types
 	EventFieldNameSignInEventTypes EventFieldName = "sign_in_event_types"
+	//  Signal Source. CMA Name: Signal Source
+	EventFieldNameSignalSource EventFieldName = "signal_source"
 	//  For IPS and SAM, ID of the IPS signature. CMA Name: Signature ID
 	EventFieldNameSignatureID EventFieldName = "signature_id"
 	//  Site web proxy instance ID. CMA Name: Site Web Proxy ID
@@ -23229,6 +23274,7 @@ var AllEventFieldName = []EventFieldName{
 	EventFieldNameDirectorySyncResult,
 	EventFieldNameDirectorySyncType,
 	EventFieldNameDisinfectResult,
+	EventFieldNameDisplayName,
 	EventFieldNameDlpFailMode,
 	EventFieldNameDlpProfiles,
 	EventFieldNameDlpScanTypes,
@@ -23282,6 +23328,7 @@ var AllEventFieldName = []EventFieldName{
 	EventFieldNameIndication,
 	EventFieldNameIndicator,
 	EventFieldNameInitialObjectStatus,
+	EventFieldNameInspectionMode,
 	EventFieldNameInteractionID,
 	EventFieldNameInteractionIntent,
 	EventFieldNameInteractionSubTopic,
@@ -23294,12 +23341,16 @@ var AllEventFieldName = []EventFieldName{
 	EventFieldNameIsAdminActivity,
 	EventFieldNameIsCloudApp,
 	EventFieldNameIsCompliant,
+	EventFieldNameIsEncrypted,
 	EventFieldNameIsManaged,
+	EventFieldNameIsPublic,
 	EventFieldNameIsSanctionedApp,
 	EventFieldNameIsSinkhole,
 	EventFieldNameJobTitle,
 	EventFieldNameKeyName,
 	EventFieldNameLabels,
+	EventFieldNameLastModifiedAt,
+	EventFieldNameLastSeenAt,
 	EventFieldNameLastTurnRole,
 	EventFieldNameLinkHealthIsCongested,
 	EventFieldNameLinkHealthJitter,
@@ -23308,6 +23359,7 @@ var AllEventFieldName = []EventFieldName{
 	EventFieldNameLinkType,
 	EventFieldNameLoggedInUser,
 	EventFieldNameLoginType,
+	EventFieldNameMatchedCount,
 	EventFieldNameMatchedDataTypes,
 	EventFieldNameMessageID,
 	EventFieldNameMetric,
@@ -23362,6 +23414,7 @@ var AllEventFieldName = []EventFieldName{
 	EventFieldNameRuleID,
 	EventFieldNameRuleName,
 	EventFieldNameSecondarySocketSerial,
+	EventFieldNameSensitivityDisplayName,
 	EventFieldNameServerIP,
 	EventFieldNameServerKeyExchangeAlgorithm,
 	EventFieldNameServiceName,
@@ -23369,6 +23422,7 @@ var AllEventFieldName = []EventFieldName{
 	EventFieldNameSeverity,
 	EventFieldNameSharingScope,
 	EventFieldNameSignInEventTypes,
+	EventFieldNameSignalSource,
 	EventFieldNameSignatureID,
 	EventFieldNameSiteWebProxyID,
 	EventFieldNameSiteWebProxyName,
@@ -23485,7 +23539,7 @@ var AllEventFieldName = []EventFieldName{
 
 func (e EventFieldName) IsValid() bool {
 	switch e {
-	case EventFieldNameIspName, EventFieldNameAccessMethod, EventFieldNameAccessPointID, EventFieldNameAccessPointName, EventFieldNameAccountID, EventFieldNameAction, EventFieldNameActionsTaken, EventFieldNameActivityResourceID, EventFieldNameActorType, EventFieldNameAdName, EventFieldNameAiAppRiskLevel, EventFieldNameAiProxyRuleName, EventFieldNameAiReason, EventFieldNameAlertID, EventFieldNameAlertName, EventFieldNameAlwaysOnConfiguration, EventFieldNameAnalystVerdict, EventFieldNameAntiTamperBypassDurationSec, EventFieldNameAntiTamperBypassMethod, EventFieldNameAntiTamperBypassResult, EventFieldNameAPIName, EventFieldNameAPIType, EventFieldNameAppActivity, EventFieldNameAppActivityCategory, EventFieldNameAppActivityType, EventFieldNameAppStack, EventFieldNameApplicationID, EventFieldNameApplicationName, EventFieldNameApplicationRisk, EventFieldNameApplicationType, EventFieldNameAtpFeedReasons, EventFieldNameAuditID, EventFieldNameAuthMethod, EventFieldNameAuthenticationType, EventFieldNameBaselineAverage, EventFieldNameBaselineStd, EventFieldNameBgpCatoAsn, EventFieldNameBgpCatoIP, EventFieldNameBgpErrorCode, EventFieldNameBgpPeerAsn, EventFieldNameBgpPeerIP, EventFieldNameBgpRouteCidr, EventFieldNameBgpSuberrorCode, EventFieldNameBrowserType, EventFieldNameBrowserVersion, EventFieldNameBypassDurationSec, EventFieldNameBypassMethod, EventFieldNameBypassReason, EventFieldNameCategories, EventFieldNameCatoApp, EventFieldNameChanges, EventFieldNameClassification, EventFieldNameClientCertExpires, EventFieldNameClientCertName, EventFieldNameClientClass, EventFieldNameClientConnectionMode, EventFieldNameClientIP, EventFieldNameClientKeyExchangeAlgorithm, EventFieldNameClientVersion, EventFieldNameCollaboratorName, EventFieldNameCollaboratorOrigin, EventFieldNameCollaboratorTenant, EventFieldNameCollaborators, EventFieldNameConfidenceLevel, EventFieldNameConfiguredHostName, EventFieldNameCongestionAlgorithm, EventFieldNameConnectOnBoot, EventFieldNameConnectionOrigin, EventFieldNameConnectorID, EventFieldNameConnectorName, EventFieldNameConnectorStatus, EventFieldNameConnectorType, EventFieldNameContainerName, EventFieldNameCorrelationID, EventFieldNameCPUCoreID, EventFieldNameCriticality, EventFieldNameCustomCategoryID, EventFieldNameCustomCategoryName, EventFieldNameDataCategories, EventFieldNameDataClassifiers, EventFieldNameDepartment, EventFieldNameDestCountry, EventFieldNameDestCountryCode, EventFieldNameDestDomain, EventFieldNameDestEndpointType, EventFieldNameDestGroupID, EventFieldNameDestGroupName, EventFieldNameDestIP, EventFieldNameDestIsSiteOrVpn, EventFieldNameDestPid, EventFieldNameDestPort, EventFieldNameDestProcessCmdline, EventFieldNameDestProcessParentPath, EventFieldNameDestProcessParentPid, EventFieldNameDestProcessPath, EventFieldNameDestSiteID, EventFieldNameDestSiteName, EventFieldNameDetectionName, EventFieldNameDetectionStage, EventFieldNameDetectors, EventFieldNameDeviceCategories, EventFieldNameDeviceCertificate, EventFieldNameDeviceComplianceState, EventFieldNameDeviceID, EventFieldNameDeviceManufacturer, EventFieldNameDeviceModel, EventFieldNameDeviceName, EventFieldNameDeviceOsType, EventFieldNameDevicePostureProfile, EventFieldNameDeviceType, EventFieldNameDirectoryHostName, EventFieldNameDirectoryIP, EventFieldNameDirectorySyncResult, EventFieldNameDirectorySyncType, EventFieldNameDisinfectResult, EventFieldNameDlpFailMode, EventFieldNameDlpProfiles, EventFieldNameDlpScanTypes, EventFieldNameDNSAnswer, EventFieldNameDNSProtectionCategory, EventFieldNameDNSQuery, EventFieldNameDNSRecordType, EventFieldNameDNSReplyCode, EventFieldNameDomainName, EventFieldNameDurationMs, EventFieldNameDynamicControlIds, EventFieldNameDynamicControlNames, EventFieldNameDynamicControlScope, EventFieldNameDynamicControlThreatCategories, EventFieldNameEgressPopName, EventFieldNameEgressSiteName, EventFieldNameEmailSubject, EventFieldNameEndpointID, EventFieldNameEngagementOutcomeAction, EventFieldNameEngineType, EventFieldNameEppEngineType, EventFieldNameEppProfile, EventFieldNameEventCount, EventFieldNameEventID, EventFieldNameEventMessage, EventFieldNameEventSubType, EventFieldNameEventType, EventFieldNameFailureReason, EventFieldNameFileHash, EventFieldNameFileName, EventFieldNameFileOperation, EventFieldNameFilePath, EventFieldNameFileSize, EventFieldNameFileTopic, EventFieldNameFileTopicCategory, EventFieldNameFileType, EventFieldNameFinalObjectStatus, EventFieldNameFlowID, EventFieldNameFlowsCardinality, EventFieldNameFullPathURL, EventFieldNameGuardID, EventFieldNameGuardName, EventFieldNameGuardType, EventFieldNameGuestUser, EventFieldNameHostIP, EventFieldNameHostMac, EventFieldNameHTTPRequestMethod, EventFieldNameHTTPResponseCode, EventFieldNameIncidentAggregation, EventFieldNameIncidentID, EventFieldNameIndication, EventFieldNameIndicator, EventFieldNameInitialObjectStatus, EventFieldNameInteractionID, EventFieldNameInteractionIntent, EventFieldNameInteractionSubTopic, EventFieldNameInteractionTopic, EventFieldNameInternalID, EventFieldNameInvestigationTimeWindow, EventFieldNameInvocationID, EventFieldNameIPProtocol, EventFieldNameIsAdmin, EventFieldNameIsAdminActivity, EventFieldNameIsCloudApp, EventFieldNameIsCompliant, EventFieldNameIsManaged, EventFieldNameIsSanctionedApp, EventFieldNameIsSinkhole, EventFieldNameJobTitle, EventFieldNameKeyName, EventFieldNameLabels, EventFieldNameLastTurnRole, EventFieldNameLinkHealthIsCongested, EventFieldNameLinkHealthJitter, EventFieldNameLinkHealthLatency, EventFieldNameLinkHealthPktLoss, EventFieldNameLinkType, EventFieldNameLoggedInUser, EventFieldNameLoginType, EventFieldNameMatchedDataTypes, EventFieldNameMessageID, EventFieldNameMetric, EventFieldNameMetricValue, EventFieldNameMitreAttackSubtechniques, EventFieldNameMitreAttackTactics, EventFieldNameMitreAttackTechniques, EventFieldNameNatError, EventFieldNameNetworkAccess, EventFieldNameNetworkRule, EventFieldNameNotificationAPIError, EventFieldNameNotificationDescription, EventFieldNameObjectID, EventFieldNameObjectModule, EventFieldNameObjectName, EventFieldNameObjectType, EventFieldNameOfficeMode, EventFieldNameOsType, EventFieldNameOsVersion, EventFieldNameOutOfBandAccess, EventFieldNameOutpostEnvironmentName, EventFieldNameOwner, EventFieldNamePacFile, EventFieldNameParentConnectorName, EventFieldNamePopName, EventFieldNamePrecedence, EventFieldNameProcessesCount, EventFieldNameProducer, EventFieldNameProjects, EventFieldNamePromptAction, EventFieldNameProviderName, EventFieldNamePublicIP, EventFieldNameQosPriority, EventFieldNameQosReportedTime, EventFieldNameQuarantineFolderPath, EventFieldNameQuarantineUUID, EventFieldNameRawData, EventFieldNameRbiProfile, EventFieldNameRecommendedActions, EventFieldNameReferenceURL, EventFieldNameRefererURL, EventFieldNameRegionName, EventFieldNameRegistrationCode, EventFieldNameRequestSize, EventFieldNameResourceID, EventFieldNameResourceName, EventFieldNameResourceType, EventFieldNameResponseSize, EventFieldNameRiskLevel, EventFieldNameRole, EventFieldNameRuleExpirationTime, EventFieldNameRuleID, EventFieldNameRuleName, EventFieldNameSecondarySocketSerial, EventFieldNameServerIP, EventFieldNameServerKeyExchangeAlgorithm, EventFieldNameServiceName, EventFieldNameSessionID, EventFieldNameSeverity, EventFieldNameSharingScope, EventFieldNameSignInEventTypes, EventFieldNameSignatureID, EventFieldNameSiteWebProxyID, EventFieldNameSiteWebProxyName, EventFieldNameSiteWebProxyRuleAction, EventFieldNameSiteWebProxyRuleID, EventFieldNameSiteWebProxyRuleName, EventFieldNameSocketDescription, EventFieldNameSocketInterface, EventFieldNameSocketInterfaceID, EventFieldNameSocketMacAddress, EventFieldNameSocketNewVersion, EventFieldNameSocketOldVersion, EventFieldNameSocketReset, EventFieldNameSocketRole, EventFieldNameSocketSerial, EventFieldNameSocketVersion, EventFieldNameSplitTunnelConfiguration, EventFieldNameSrcCountry, EventFieldNameSrcCountryCode, EventFieldNameSrcEndpointType, EventFieldNameSrcIP, EventFieldNameSrcIsSiteOrVpn, EventFieldNameSrcIspIP, EventFieldNameSrcPid, EventFieldNameSrcPort, EventFieldNameSrcProcessCmdline, EventFieldNameSrcProcessParentPath, EventFieldNameSrcProcessParentPid, EventFieldNameSrcProcessPath, EventFieldNameSrcSiteConnectionType, EventFieldNameSrcSiteID, EventFieldNameSrcSiteName, EventFieldNameStaticHost, EventFieldNameStatus, EventFieldNameStoryID, EventFieldNameSubnetName, EventFieldNameSubscriptionName, EventFieldNameTargetsCardinality, EventFieldNameTCPAcceleration, EventFieldNameTenantID, EventFieldNameTenantName, EventFieldNameTenantRestrictionRuleName, EventFieldNameThreatConfidence, EventFieldNameThreatName, EventFieldNameThreatReference, EventFieldNameThreatScore, EventFieldNameThreatType, EventFieldNameThreatVerdict, EventFieldNameTime, EventFieldNameTimeStr, EventFieldNameTitle, EventFieldNameTLSCertificateError, EventFieldNameTLSErrorDescription, EventFieldNameTLSErrorType, EventFieldNameTLSInspection, EventFieldNameTLSRuleName, EventFieldNameTLSVersion, EventFieldNameTotalTokens, EventFieldNameTrafficDirection, EventFieldNameTransactionSize, EventFieldNameTranslatedClientIP, EventFieldNameTranslatedServerIP, EventFieldNameTrigger, EventFieldNameTrustType, EventFieldNameTrustedNetworks, EventFieldNameTunnelIPProtocol, EventFieldNameTunnelProtocol, EventFieldNameUpgradeEndTime, EventFieldNameUpgradeInitiatedBy, EventFieldNameUpgradeStartTime, EventFieldNameURL, EventFieldNameUserAgent, EventFieldNameUserAwarenessMethod, EventFieldNameUserID, EventFieldNameUserJustification, EventFieldNameUserName, EventFieldNameUserOrigin, EventFieldNameUserReferenceID, EventFieldNameUserRiskLevel, EventFieldNameVendor, EventFieldNameVendorCollaboratorID, EventFieldNameVendorDeviceID, EventFieldNameVendorDeviceName, EventFieldNameVendorEventID, EventFieldNameVendorLocation, EventFieldNameVendorOrgID, EventFieldNameVendorPolicyDescription, EventFieldNameVendorPolicyID, EventFieldNameVendorPolicyName, EventFieldNameVendorSiteID, EventFieldNameVendorStartTime, EventFieldNameVendorUserID, EventFieldNameVendorVersion, EventFieldNameVisibleDeviceID, EventFieldNameVpnLanAccess, EventFieldNameVpnUserEmail, EventFieldNameWifiAuthenticationType, EventFieldNameWifiBssid, EventFieldNameWifiChannel, EventFieldNameWifiDescription, EventFieldNameWifiEventReasonCode, EventFieldNameWifiEventType, EventFieldNameWifiEventTypeCode, EventFieldNameWifiEventVendorName, EventFieldNameWifiProtocol, EventFieldNameWifiRadioBand, EventFieldNameWifiSecurity, EventFieldNameWifiSignalStrength, EventFieldNameWifiSsid, EventFieldNameWifiTimeSinceAssocMs, EventFieldNameWindowsDomainName, EventFieldNameXff:
+	case EventFieldNameIspName, EventFieldNameAccessMethod, EventFieldNameAccessPointID, EventFieldNameAccessPointName, EventFieldNameAccountID, EventFieldNameAction, EventFieldNameActionsTaken, EventFieldNameActivityResourceID, EventFieldNameActorType, EventFieldNameAdName, EventFieldNameAiAppRiskLevel, EventFieldNameAiProxyRuleName, EventFieldNameAiReason, EventFieldNameAlertID, EventFieldNameAlertName, EventFieldNameAlwaysOnConfiguration, EventFieldNameAnalystVerdict, EventFieldNameAntiTamperBypassDurationSec, EventFieldNameAntiTamperBypassMethod, EventFieldNameAntiTamperBypassResult, EventFieldNameAPIName, EventFieldNameAPIType, EventFieldNameAppActivity, EventFieldNameAppActivityCategory, EventFieldNameAppActivityType, EventFieldNameAppStack, EventFieldNameApplicationID, EventFieldNameApplicationName, EventFieldNameApplicationRisk, EventFieldNameApplicationType, EventFieldNameAtpFeedReasons, EventFieldNameAuditID, EventFieldNameAuthMethod, EventFieldNameAuthenticationType, EventFieldNameBaselineAverage, EventFieldNameBaselineStd, EventFieldNameBgpCatoAsn, EventFieldNameBgpCatoIP, EventFieldNameBgpErrorCode, EventFieldNameBgpPeerAsn, EventFieldNameBgpPeerIP, EventFieldNameBgpRouteCidr, EventFieldNameBgpSuberrorCode, EventFieldNameBrowserType, EventFieldNameBrowserVersion, EventFieldNameBypassDurationSec, EventFieldNameBypassMethod, EventFieldNameBypassReason, EventFieldNameCategories, EventFieldNameCatoApp, EventFieldNameChanges, EventFieldNameClassification, EventFieldNameClientCertExpires, EventFieldNameClientCertName, EventFieldNameClientClass, EventFieldNameClientConnectionMode, EventFieldNameClientIP, EventFieldNameClientKeyExchangeAlgorithm, EventFieldNameClientVersion, EventFieldNameCollaboratorName, EventFieldNameCollaboratorOrigin, EventFieldNameCollaboratorTenant, EventFieldNameCollaborators, EventFieldNameConfidenceLevel, EventFieldNameConfiguredHostName, EventFieldNameCongestionAlgorithm, EventFieldNameConnectOnBoot, EventFieldNameConnectionOrigin, EventFieldNameConnectorID, EventFieldNameConnectorName, EventFieldNameConnectorStatus, EventFieldNameConnectorType, EventFieldNameContainerName, EventFieldNameCorrelationID, EventFieldNameCPUCoreID, EventFieldNameCriticality, EventFieldNameCustomCategoryID, EventFieldNameCustomCategoryName, EventFieldNameDataCategories, EventFieldNameDataClassifiers, EventFieldNameDepartment, EventFieldNameDestCountry, EventFieldNameDestCountryCode, EventFieldNameDestDomain, EventFieldNameDestEndpointType, EventFieldNameDestGroupID, EventFieldNameDestGroupName, EventFieldNameDestIP, EventFieldNameDestIsSiteOrVpn, EventFieldNameDestPid, EventFieldNameDestPort, EventFieldNameDestProcessCmdline, EventFieldNameDestProcessParentPath, EventFieldNameDestProcessParentPid, EventFieldNameDestProcessPath, EventFieldNameDestSiteID, EventFieldNameDestSiteName, EventFieldNameDetectionName, EventFieldNameDetectionStage, EventFieldNameDetectors, EventFieldNameDeviceCategories, EventFieldNameDeviceCertificate, EventFieldNameDeviceComplianceState, EventFieldNameDeviceID, EventFieldNameDeviceManufacturer, EventFieldNameDeviceModel, EventFieldNameDeviceName, EventFieldNameDeviceOsType, EventFieldNameDevicePostureProfile, EventFieldNameDeviceType, EventFieldNameDirectoryHostName, EventFieldNameDirectoryIP, EventFieldNameDirectorySyncResult, EventFieldNameDirectorySyncType, EventFieldNameDisinfectResult, EventFieldNameDisplayName, EventFieldNameDlpFailMode, EventFieldNameDlpProfiles, EventFieldNameDlpScanTypes, EventFieldNameDNSAnswer, EventFieldNameDNSProtectionCategory, EventFieldNameDNSQuery, EventFieldNameDNSRecordType, EventFieldNameDNSReplyCode, EventFieldNameDomainName, EventFieldNameDurationMs, EventFieldNameDynamicControlIds, EventFieldNameDynamicControlNames, EventFieldNameDynamicControlScope, EventFieldNameDynamicControlThreatCategories, EventFieldNameEgressPopName, EventFieldNameEgressSiteName, EventFieldNameEmailSubject, EventFieldNameEndpointID, EventFieldNameEngagementOutcomeAction, EventFieldNameEngineType, EventFieldNameEppEngineType, EventFieldNameEppProfile, EventFieldNameEventCount, EventFieldNameEventID, EventFieldNameEventMessage, EventFieldNameEventSubType, EventFieldNameEventType, EventFieldNameFailureReason, EventFieldNameFileHash, EventFieldNameFileName, EventFieldNameFileOperation, EventFieldNameFilePath, EventFieldNameFileSize, EventFieldNameFileTopic, EventFieldNameFileTopicCategory, EventFieldNameFileType, EventFieldNameFinalObjectStatus, EventFieldNameFlowID, EventFieldNameFlowsCardinality, EventFieldNameFullPathURL, EventFieldNameGuardID, EventFieldNameGuardName, EventFieldNameGuardType, EventFieldNameGuestUser, EventFieldNameHostIP, EventFieldNameHostMac, EventFieldNameHTTPRequestMethod, EventFieldNameHTTPResponseCode, EventFieldNameIncidentAggregation, EventFieldNameIncidentID, EventFieldNameIndication, EventFieldNameIndicator, EventFieldNameInitialObjectStatus, EventFieldNameInspectionMode, EventFieldNameInteractionID, EventFieldNameInteractionIntent, EventFieldNameInteractionSubTopic, EventFieldNameInteractionTopic, EventFieldNameInternalID, EventFieldNameInvestigationTimeWindow, EventFieldNameInvocationID, EventFieldNameIPProtocol, EventFieldNameIsAdmin, EventFieldNameIsAdminActivity, EventFieldNameIsCloudApp, EventFieldNameIsCompliant, EventFieldNameIsEncrypted, EventFieldNameIsManaged, EventFieldNameIsPublic, EventFieldNameIsSanctionedApp, EventFieldNameIsSinkhole, EventFieldNameJobTitle, EventFieldNameKeyName, EventFieldNameLabels, EventFieldNameLastModifiedAt, EventFieldNameLastSeenAt, EventFieldNameLastTurnRole, EventFieldNameLinkHealthIsCongested, EventFieldNameLinkHealthJitter, EventFieldNameLinkHealthLatency, EventFieldNameLinkHealthPktLoss, EventFieldNameLinkType, EventFieldNameLoggedInUser, EventFieldNameLoginType, EventFieldNameMatchedCount, EventFieldNameMatchedDataTypes, EventFieldNameMessageID, EventFieldNameMetric, EventFieldNameMetricValue, EventFieldNameMitreAttackSubtechniques, EventFieldNameMitreAttackTactics, EventFieldNameMitreAttackTechniques, EventFieldNameNatError, EventFieldNameNetworkAccess, EventFieldNameNetworkRule, EventFieldNameNotificationAPIError, EventFieldNameNotificationDescription, EventFieldNameObjectID, EventFieldNameObjectModule, EventFieldNameObjectName, EventFieldNameObjectType, EventFieldNameOfficeMode, EventFieldNameOsType, EventFieldNameOsVersion, EventFieldNameOutOfBandAccess, EventFieldNameOutpostEnvironmentName, EventFieldNameOwner, EventFieldNamePacFile, EventFieldNameParentConnectorName, EventFieldNamePopName, EventFieldNamePrecedence, EventFieldNameProcessesCount, EventFieldNameProducer, EventFieldNameProjects, EventFieldNamePromptAction, EventFieldNameProviderName, EventFieldNamePublicIP, EventFieldNameQosPriority, EventFieldNameQosReportedTime, EventFieldNameQuarantineFolderPath, EventFieldNameQuarantineUUID, EventFieldNameRawData, EventFieldNameRbiProfile, EventFieldNameRecommendedActions, EventFieldNameReferenceURL, EventFieldNameRefererURL, EventFieldNameRegionName, EventFieldNameRegistrationCode, EventFieldNameRequestSize, EventFieldNameResourceID, EventFieldNameResourceName, EventFieldNameResourceType, EventFieldNameResponseSize, EventFieldNameRiskLevel, EventFieldNameRole, EventFieldNameRuleExpirationTime, EventFieldNameRuleID, EventFieldNameRuleName, EventFieldNameSecondarySocketSerial, EventFieldNameSensitivityDisplayName, EventFieldNameServerIP, EventFieldNameServerKeyExchangeAlgorithm, EventFieldNameServiceName, EventFieldNameSessionID, EventFieldNameSeverity, EventFieldNameSharingScope, EventFieldNameSignInEventTypes, EventFieldNameSignalSource, EventFieldNameSignatureID, EventFieldNameSiteWebProxyID, EventFieldNameSiteWebProxyName, EventFieldNameSiteWebProxyRuleAction, EventFieldNameSiteWebProxyRuleID, EventFieldNameSiteWebProxyRuleName, EventFieldNameSocketDescription, EventFieldNameSocketInterface, EventFieldNameSocketInterfaceID, EventFieldNameSocketMacAddress, EventFieldNameSocketNewVersion, EventFieldNameSocketOldVersion, EventFieldNameSocketReset, EventFieldNameSocketRole, EventFieldNameSocketSerial, EventFieldNameSocketVersion, EventFieldNameSplitTunnelConfiguration, EventFieldNameSrcCountry, EventFieldNameSrcCountryCode, EventFieldNameSrcEndpointType, EventFieldNameSrcIP, EventFieldNameSrcIsSiteOrVpn, EventFieldNameSrcIspIP, EventFieldNameSrcPid, EventFieldNameSrcPort, EventFieldNameSrcProcessCmdline, EventFieldNameSrcProcessParentPath, EventFieldNameSrcProcessParentPid, EventFieldNameSrcProcessPath, EventFieldNameSrcSiteConnectionType, EventFieldNameSrcSiteID, EventFieldNameSrcSiteName, EventFieldNameStaticHost, EventFieldNameStatus, EventFieldNameStoryID, EventFieldNameSubnetName, EventFieldNameSubscriptionName, EventFieldNameTargetsCardinality, EventFieldNameTCPAcceleration, EventFieldNameTenantID, EventFieldNameTenantName, EventFieldNameTenantRestrictionRuleName, EventFieldNameThreatConfidence, EventFieldNameThreatName, EventFieldNameThreatReference, EventFieldNameThreatScore, EventFieldNameThreatType, EventFieldNameThreatVerdict, EventFieldNameTime, EventFieldNameTimeStr, EventFieldNameTitle, EventFieldNameTLSCertificateError, EventFieldNameTLSErrorDescription, EventFieldNameTLSErrorType, EventFieldNameTLSInspection, EventFieldNameTLSRuleName, EventFieldNameTLSVersion, EventFieldNameTotalTokens, EventFieldNameTrafficDirection, EventFieldNameTransactionSize, EventFieldNameTranslatedClientIP, EventFieldNameTranslatedServerIP, EventFieldNameTrigger, EventFieldNameTrustType, EventFieldNameTrustedNetworks, EventFieldNameTunnelIPProtocol, EventFieldNameTunnelProtocol, EventFieldNameUpgradeEndTime, EventFieldNameUpgradeInitiatedBy, EventFieldNameUpgradeStartTime, EventFieldNameURL, EventFieldNameUserAgent, EventFieldNameUserAwarenessMethod, EventFieldNameUserID, EventFieldNameUserJustification, EventFieldNameUserName, EventFieldNameUserOrigin, EventFieldNameUserReferenceID, EventFieldNameUserRiskLevel, EventFieldNameVendor, EventFieldNameVendorCollaboratorID, EventFieldNameVendorDeviceID, EventFieldNameVendorDeviceName, EventFieldNameVendorEventID, EventFieldNameVendorLocation, EventFieldNameVendorOrgID, EventFieldNameVendorPolicyDescription, EventFieldNameVendorPolicyID, EventFieldNameVendorPolicyName, EventFieldNameVendorSiteID, EventFieldNameVendorStartTime, EventFieldNameVendorUserID, EventFieldNameVendorVersion, EventFieldNameVisibleDeviceID, EventFieldNameVpnLanAccess, EventFieldNameVpnUserEmail, EventFieldNameWifiAuthenticationType, EventFieldNameWifiBssid, EventFieldNameWifiChannel, EventFieldNameWifiDescription, EventFieldNameWifiEventReasonCode, EventFieldNameWifiEventType, EventFieldNameWifiEventTypeCode, EventFieldNameWifiEventVendorName, EventFieldNameWifiProtocol, EventFieldNameWifiRadioBand, EventFieldNameWifiSecurity, EventFieldNameWifiSignalStrength, EventFieldNameWifiSsid, EventFieldNameWifiTimeSinceAssocMs, EventFieldNameWindowsDomainName, EventFieldNameXff:
 		return true
 	}
 	return false
@@ -30964,22 +31018,38 @@ func (e StoryStatusEnum) MarshalJSON() ([]byte, error) {
 type StoryVerdictEnum string
 
 const (
-	StoryVerdictEnumBenign        StoryVerdictEnum = "Benign"
-	StoryVerdictEnumInformational StoryVerdictEnum = "Informational"
-	StoryVerdictEnumMalicious     StoryVerdictEnum = "Malicious"
-	StoryVerdictEnumSuspicious    StoryVerdictEnum = "Suspicious"
+	StoryVerdictEnumBenign             StoryVerdictEnum = "Benign"
+	StoryVerdictEnumConfigurationIssue StoryVerdictEnum = "ConfigurationIssue"
+	StoryVerdictEnumFalsePositive      StoryVerdictEnum = "FalsePositive"
+	StoryVerdictEnumHardwareIssue      StoryVerdictEnum = "HardwareIssue"
+	StoryVerdictEnumInformational      StoryVerdictEnum = "Informational"
+	StoryVerdictEnumInsufficientData   StoryVerdictEnum = "InsufficientData"
+	StoryVerdictEnumMalicious          StoryVerdictEnum = "Malicious"
+	StoryVerdictEnumOverlayIssue       StoryVerdictEnum = "OverlayIssue"
+	StoryVerdictEnumPlannedMaintenance StoryVerdictEnum = "PlannedMaintenance"
+	StoryVerdictEnumSelfRecovered      StoryVerdictEnum = "SelfRecovered"
+	StoryVerdictEnumSuspicious         StoryVerdictEnum = "Suspicious"
+	StoryVerdictEnumUnderlayIssue      StoryVerdictEnum = "UnderlayIssue"
 )
 
 var AllStoryVerdictEnum = []StoryVerdictEnum{
 	StoryVerdictEnumBenign,
+	StoryVerdictEnumConfigurationIssue,
+	StoryVerdictEnumFalsePositive,
+	StoryVerdictEnumHardwareIssue,
 	StoryVerdictEnumInformational,
+	StoryVerdictEnumInsufficientData,
 	StoryVerdictEnumMalicious,
+	StoryVerdictEnumOverlayIssue,
+	StoryVerdictEnumPlannedMaintenance,
+	StoryVerdictEnumSelfRecovered,
 	StoryVerdictEnumSuspicious,
+	StoryVerdictEnumUnderlayIssue,
 }
 
 func (e StoryVerdictEnum) IsValid() bool {
 	switch e {
-	case StoryVerdictEnumBenign, StoryVerdictEnumInformational, StoryVerdictEnumMalicious, StoryVerdictEnumSuspicious:
+	case StoryVerdictEnumBenign, StoryVerdictEnumConfigurationIssue, StoryVerdictEnumFalsePositive, StoryVerdictEnumHardwareIssue, StoryVerdictEnumInformational, StoryVerdictEnumInsufficientData, StoryVerdictEnumMalicious, StoryVerdictEnumOverlayIssue, StoryVerdictEnumPlannedMaintenance, StoryVerdictEnumSelfRecovered, StoryVerdictEnumSuspicious, StoryVerdictEnumUnderlayIssue:
 		return true
 	}
 	return false


### PR DESCRIPTION
## Summary
- Refreshes cato_api.graphqls from the upstream Cato schema endpoint.
- Applies and validates schema patches, deleting patch files that upstream now includes.
- Regenerates the Go SDK client/models and verifies `go build ./...`.

## Test plan
- `bash scripts/schema_update_ci.sh`
