### PR TITLE
Update generated SDK schema

### DIFF
--- a/cato_api.graphqls
+++ b/cato_api.graphqls
@@ -54,7 +54,7 @@ type Query {
   networkConfig(accountId: ID!): NetworkConfigQueries
   notification(accountId: ID!): NotificationSubscriptionQueries @ga
   object(accountId: ID!): ObjectQueries
-  policy(accountId: ID!): PolicyQueries
+  policy(accountId: ID!): PolicyQueries!
   popLocations(accountId: ID!): PopLocationQueries
   privateApplication(accountId: ID!): AccessPrivateApplicationQueries @rollout
   sandbox(accountId: ID!): SandboxQueries @rollout
@@ -75,6 +75,7 @@ type Mutation {
   businessPlatform(accountId: ID!): BusinessPlatformMutations @rollout
   container(accountId: ID!): ContainerMutations
   customAppData(accountId: ID!): CustomAppDataMutations!
+  encryptKeytabFile(accountId: ID!, input: EncryptKeytabFileInput!): EncryptKeytabFilePayload! @beta
   enterpriseDirectory(accountId: ID!): EnterpriseDirectoryMutations
   externalAccess(accountId: ID!): ExternalAccessMutations!
   groups(accountId: ID!): GroupsMutations
@@ -83,7 +84,7 @@ type Mutation {
   networkConfig(accountId: ID!): NetworkConfigMutations
   notification(accountId: ID!): NotificationSubscriptionMutations @ga
   object(accountId: ID!): ObjectMutations
-  policy(accountId: ID!): PolicyMutations
+  policy(accountId: ID!): PolicyMutations!
   popLocationMutations(accountId: ID!): PopLocationMutations
   privateApplication(accountId: ID!): AccessPrivateApplicationMutations @rollout
   sandbox(accountId: ID!): SandboxMutations @rollout
@@ -130,11 +131,6 @@ type AccessPrivateApplicationMutations {
 type AccessPrivateApplicationQueries {
   privateApplication(input: PrivateApplicationRefInput!): PrivateApplication @beta
   privateApplicationList(input: PrivateApplicationListInput): PrivateApplicationListPayload @beta
-}
-
-type AccessTokenRef implements ObjectRef {
-  id: ID!
-  name: String!
 }
 
 type AccountAuditData {
@@ -668,23 +664,23 @@ type AntiMalwareFileHashPolicyMutationPayload implements IPolicyMutationPayload 
 }
 
 type AntiMalwareFileHashPolicyMutations {
-  addRule(input: AntiMalwareFileHashAddRuleInput!): AntiMalwareFileHashRuleMutationPayload! @beta
-  addSection(input: PolicyAddSectionInput!): PolicySectionMutationPayload! @beta
-  createPolicyRevision(input: PolicyCreateRevisionInput!): AntiMalwareFileHashPolicyMutationPayload! @beta
-  discardPolicyRevision(input: PolicyDiscardRevisionInput): AntiMalwareFileHashPolicyMutationPayload! @beta
-  moveRule(input: PolicyMoveRuleInput!): AntiMalwareFileHashRuleMutationPayload! @beta
-  moveSection(input: PolicyMoveSectionInput!): PolicySectionMutationPayload! @beta
-  publishPolicyRevision(input: PolicyPublishRevisionInput): AntiMalwareFileHashPolicyMutationPayload! @beta
-  removeRule(input: AntiMalwareFileHashRemoveRuleInput!): AntiMalwareFileHashRuleMutationPayload! @beta
-  removeSection(input: PolicyRemoveSectionInput!): PolicySectionMutationPayload! @beta
-  updatePolicy(input: AntiMalwareFileHashPolicyUpdateInput!): AntiMalwareFileHashPolicyMutationPayload! @beta
-  updateRule(input: AntiMalwareFileHashUpdateRuleInput!): AntiMalwareFileHashRuleMutationPayload! @beta
-  updateSection(input: PolicyUpdateSectionInput!): PolicySectionMutationPayload! @beta
+  addRule(input: AntiMalwareFileHashAddRuleInput!): AntiMalwareFileHashRuleMutationPayload!
+  addSection(input: PolicyAddSectionInput!): PolicySectionMutationPayload!
+  createPolicyRevision(input: PolicyCreateRevisionInput!): AntiMalwareFileHashPolicyMutationPayload!
+  discardPolicyRevision(input: PolicyDiscardRevisionInput): AntiMalwareFileHashPolicyMutationPayload!
+  moveRule(input: PolicyMoveRuleInput!): AntiMalwareFileHashRuleMutationPayload!
+  moveSection(input: PolicyMoveSectionInput!): PolicySectionMutationPayload!
+  publishPolicyRevision(input: PolicyPublishRevisionInput): AntiMalwareFileHashPolicyMutationPayload!
+  removeRule(input: AntiMalwareFileHashRemoveRuleInput!): AntiMalwareFileHashRuleMutationPayload!
+  removeSection(input: PolicyRemoveSectionInput!): PolicySectionMutationPayload!
+  updatePolicy(input: AntiMalwareFileHashPolicyUpdateInput!): AntiMalwareFileHashPolicyMutationPayload!
+  updateRule(input: AntiMalwareFileHashUpdateRuleInput!): AntiMalwareFileHashRuleMutationPayload!
+  updateSection(input: PolicyUpdateSectionInput!): PolicySectionMutationPayload!
 }
 
 type AntiMalwareFileHashPolicyQueries {
-  policy(input: AntiMalwareFileHashPolicyInput): AntiMalwareFileHashPolicy! @beta
-  revisions: PolicyRevisionsPayload @beta
+  policy(input: AntiMalwareFileHashPolicyInput): AntiMalwareFileHashPolicy!
+  revisions: PolicyRevisionsPayload
 }
 
 type AntiMalwareFileHashRule implements IPolicyRule {
@@ -770,23 +766,23 @@ type AppTenantRestrictionPolicyMutationPayload implements IPolicyMutationPayload
 }
 
 type AppTenantRestrictionPolicyMutations {
-  addRule(input: AppTenantRestrictionAddRuleInput!): AppTenantRestrictionRuleMutationPayload! @beta
-  addSection(input: PolicyAddSectionInput!): PolicySectionMutationPayload! @beta
-  createPolicyRevision(input: PolicyCreateRevisionInput!): AppTenantRestrictionPolicyMutationPayload! @beta
-  discardPolicyRevision(input: PolicyDiscardRevisionInput): AppTenantRestrictionPolicyMutationPayload! @beta
-  moveRule(input: PolicyMoveRuleInput!): AppTenantRestrictionRuleMutationPayload! @beta
-  moveSection(input: PolicyMoveSectionInput!): PolicySectionMutationPayload! @beta
-  publishPolicyRevision(input: PolicyPublishRevisionInput): AppTenantRestrictionPolicyMutationPayload! @beta
-  removeRule(input: AppTenantRestrictionRemoveRuleInput!): AppTenantRestrictionRuleMutationPayload! @beta
-  removeSection(input: PolicyRemoveSectionInput!): PolicySectionMutationPayload! @beta
-  updatePolicy(input: AppTenantRestrictionPolicyUpdateInput!): AppTenantRestrictionPolicyMutationPayload! @beta
-  updateRule(input: AppTenantRestrictionUpdateRuleInput!): AppTenantRestrictionRuleMutationPayload! @beta
-  updateSection(input: PolicyUpdateSectionInput!): PolicySectionMutationPayload! @beta
+  addRule(input: AppTenantRestrictionAddRuleInput!): AppTenantRestrictionRuleMutationPayload!
+  addSection(input: PolicyAddSectionInput!): PolicySectionMutationPayload!
+  createPolicyRevision(input: PolicyCreateRevisionInput!): AppTenantRestrictionPolicyMutationPayload!
+  discardPolicyRevision(input: PolicyDiscardRevisionInput): AppTenantRestrictionPolicyMutationPayload!
+  moveRule(input: PolicyMoveRuleInput!): AppTenantRestrictionRuleMutationPayload!
+  moveSection(input: PolicyMoveSectionInput!): PolicySectionMutationPayload!
+  publishPolicyRevision(input: PolicyPublishRevisionInput): AppTenantRestrictionPolicyMutationPayload!
+  removeRule(input: AppTenantRestrictionRemoveRuleInput!): AppTenantRestrictionRuleMutationPayload!
+  removeSection(input: PolicyRemoveSectionInput!): PolicySectionMutationPayload!
+  updatePolicy(input: AppTenantRestrictionPolicyUpdateInput!): AppTenantRestrictionPolicyMutationPayload!
+  updateRule(input: AppTenantRestrictionUpdateRuleInput!): AppTenantRestrictionRuleMutationPayload!
+  updateSection(input: PolicyUpdateSectionInput!): PolicySectionMutationPayload!
 }
 
 type AppTenantRestrictionPolicyQueries {
-  policy(input: AppTenantRestrictionPolicyInput): AppTenantRestrictionPolicy! @beta
-  revisions: PolicyRevisionsPayload @beta
+  policy(input: AppTenantRestrictionPolicyInput): AppTenantRestrictionPolicy!
+  revisions: PolicyRevisionsPayload
 }
 
 type AppTenantRestrictionRule implements IPolicyRule {
@@ -1029,23 +1025,23 @@ type ApplicationControlPolicyMutationPayload implements IPolicyMutationPayload {
 }
 
 type ApplicationControlPolicyMutations {
-  addRule(input: ApplicationControlAddRuleInput!): ApplicationControlRuleMutationPayload! @beta
-  addSection(input: PolicyAddSectionInput!): PolicySectionMutationPayload! @beta
-  createPolicyRevision(input: PolicyCreateRevisionInput!): ApplicationControlPolicyMutationPayload! @beta
-  discardPolicyRevision(input: PolicyDiscardRevisionInput): ApplicationControlPolicyMutationPayload! @beta
-  moveRule(input: PolicyMoveRuleInput!): ApplicationControlRuleMutationPayload! @beta
-  moveSection(input: PolicyMoveSectionInput!): PolicySectionMutationPayload! @beta
-  publishPolicyRevision(input: PolicyPublishRevisionInput): ApplicationControlPolicyMutationPayload! @beta
-  removeRule(input: ApplicationControlRemoveRuleInput!): ApplicationControlRuleMutationPayload! @beta
-  removeSection(input: PolicyRemoveSectionInput!): PolicySectionMutationPayload! @beta
-  updatePolicy(input: ApplicationControlPolicyUpdateInput!): ApplicationControlPolicyMutationPayload! @beta
-  updateRule(input: ApplicationControlUpdateRuleInput!): ApplicationControlRuleMutationPayload! @beta
-  updateSection(input: PolicyUpdateSectionInput!): PolicySectionMutationPayload! @beta
+  addRule(input: ApplicationControlAddRuleInput!): ApplicationControlRuleMutationPayload!
+  addSection(input: PolicyAddSectionInput!): PolicySectionMutationPayload!
+  createPolicyRevision(input: PolicyCreateRevisionInput!): ApplicationControlPolicyMutationPayload!
+  discardPolicyRevision(input: PolicyDiscardRevisionInput): ApplicationControlPolicyMutationPayload!
+  moveRule(input: PolicyMoveRuleInput!): ApplicationControlRuleMutationPayload!
+  moveSection(input: PolicyMoveSectionInput!): PolicySectionMutationPayload!
+  publishPolicyRevision(input: PolicyPublishRevisionInput): ApplicationControlPolicyMutationPayload!
+  removeRule(input: ApplicationControlRemoveRuleInput!): ApplicationControlRuleMutationPayload!
+  removeSection(input: PolicyRemoveSectionInput!): PolicySectionMutationPayload!
+  updatePolicy(input: ApplicationControlPolicyUpdateInput!): ApplicationControlPolicyMutationPayload!
+  updateRule(input: ApplicationControlUpdateRuleInput!): ApplicationControlRuleMutationPayload!
+  updateSection(input: PolicyUpdateSectionInput!): PolicySectionMutationPayload!
 }
 
 type ApplicationControlPolicyQueries {
-  policy(input: ApplicationControlPolicyInput): ApplicationControlPolicy! @beta
-  revisions: PolicyRevisionsPayload @beta
+  policy(input: ApplicationControlPolicyInput): ApplicationControlPolicy!
+  revisions: PolicyRevisionsPayload
 }
 
 """ Application risk """
@@ -1417,6 +1413,7 @@ type CasbLicense implements License {
 type CatalogApplication {
   activity: [CatalogApplicationActivity!]!
   aiSecurity: AiSecurityAttributes
+  asn: [Asn32!]! @rollout
   capability: [CatalogApplicationCapability!]!
   category: [ApplicationCategoryRef!]!
   childApp: [ApplicationRef!]!
@@ -1424,6 +1421,7 @@ type CatalogApplication {
   complianceAttributes: CatalogApplicationComplianceAttributes!
   description: String
   descriptionSummary: String
+  dynamicIpSource: [String!]! @rollout
   fqdn: [Fqdn!]!
   id: ID!
   identityAccessManagementAttributes: CatalogApplicationIdentityAccessManagementAttributes
@@ -1438,6 +1436,7 @@ type CatalogApplication {
   sanctioned: Boolean!
   securityAttributes: CatalogApplicationSecurityAttributes!
   standardPorts: [CustomService!]!
+  staticIpRange: [NetworkSubnet!]! @rollout
   tenantActivity: [CatalogApplicationActivity!]!
   type: CatalogApplicationType!
   website: Url
@@ -1688,23 +1687,23 @@ type ClientConnectivityPolicyMutationPayload implements IPolicyMutationPayload {
 }
 
 type ClientConnectivityPolicyMutations {
-  addRule(input: ClientConnectivityAddRuleInput!): ClientConnectivityRuleMutationPayload! @beta
-  addSection(input: PolicyAddSectionInput!): PolicySectionMutationPayload! @beta
-  createPolicyRevision(input: PolicyCreateRevisionInput!): ClientConnectivityPolicyMutationPayload! @beta
-  discardPolicyRevision(input: PolicyDiscardRevisionInput): ClientConnectivityPolicyMutationPayload! @beta
-  moveRule(input: PolicyMoveRuleInput!): ClientConnectivityRuleMutationPayload! @beta
-  moveSection(input: PolicyMoveSectionInput!): PolicySectionMutationPayload! @beta
-  publishPolicyRevision(input: PolicyPublishRevisionInput): ClientConnectivityPolicyMutationPayload! @beta
-  removeRule(input: ClientConnectivityRemoveRuleInput!): ClientConnectivityRuleMutationPayload! @beta
-  removeSection(input: PolicyRemoveSectionInput!): PolicySectionMutationPayload! @beta
-  updatePolicy(input: ClientConnectivityPolicyUpdateInput!): ClientConnectivityPolicyMutationPayload! @beta
-  updateRule(input: ClientConnectivityUpdateRuleInput!): ClientConnectivityRuleMutationPayload! @beta
-  updateSection(input: PolicyUpdateSectionInput!): PolicySectionMutationPayload! @beta
+  addRule(input: ClientConnectivityAddRuleInput!): ClientConnectivityRuleMutationPayload!
+  addSection(input: PolicyAddSectionInput!): PolicySectionMutationPayload!
+  createPolicyRevision(input: PolicyCreateRevisionInput!): ClientConnectivityPolicyMutationPayload!
+  discardPolicyRevision(input: PolicyDiscardRevisionInput): ClientConnectivityPolicyMutationPayload!
+  moveRule(input: PolicyMoveRuleInput!): ClientConnectivityRuleMutationPayload!
+  moveSection(input: PolicyMoveSectionInput!): PolicySectionMutationPayload!
+  publishPolicyRevision(input: PolicyPublishRevisionInput): ClientConnectivityPolicyMutationPayload!
+  removeRule(input: ClientConnectivityRemoveRuleInput!): ClientConnectivityRuleMutationPayload!
+  removeSection(input: PolicyRemoveSectionInput!): PolicySectionMutationPayload!
+  updatePolicy(input: ClientConnectivityPolicyUpdateInput!): ClientConnectivityPolicyMutationPayload!
+  updateRule(input: ClientConnectivityUpdateRuleInput!): ClientConnectivityRuleMutationPayload!
+  updateSection(input: PolicyUpdateSectionInput!): PolicySectionMutationPayload!
 }
 
 type ClientConnectivityPolicyQueries {
-  policy(input: ClientConnectivityPolicyInput): ClientConnectivityPolicy! @beta
-  revisions: PolicyRevisionsPayload @beta
+  policy(input: ClientConnectivityPolicyInput): ClientConnectivityPolicy!
+  revisions: PolicyRevisionsPayload
 }
 
 type ClientConnectivityRule implements IPolicyRule {
@@ -2403,23 +2402,23 @@ type DynamicIpAllocationPolicyMutationPayload implements IPolicyMutationPayload 
 }
 
 type DynamicIpAllocationPolicyMutations {
-  addRule(input: DynamicIpAllocationAddRuleInput!): DynamicIpAllocationRuleMutationPayload! @beta
-  addSection(input: PolicyAddSectionInput!): PolicySectionMutationPayload! @beta
-  createPolicyRevision(input: PolicyCreateRevisionInput!): DynamicIpAllocationPolicyMutationPayload! @beta
-  discardPolicyRevision(input: PolicyDiscardRevisionInput): DynamicIpAllocationPolicyMutationPayload! @beta
-  moveRule(input: PolicyMoveRuleInput!): DynamicIpAllocationRuleMutationPayload! @beta
-  moveSection(input: PolicyMoveSectionInput!): PolicySectionMutationPayload! @beta
-  publishPolicyRevision(input: PolicyPublishRevisionInput): DynamicIpAllocationPolicyMutationPayload! @beta
-  removeRule(input: DynamicIpAllocationRemoveRuleInput!): DynamicIpAllocationRuleMutationPayload! @beta
-  removeSection(input: PolicyRemoveSectionInput!): PolicySectionMutationPayload! @beta
-  updatePolicy(input: DynamicIpAllocationPolicyUpdateInput!): DynamicIpAllocationPolicyMutationPayload! @beta
-  updateRule(input: DynamicIpAllocationUpdateRuleInput!): DynamicIpAllocationRuleMutationPayload! @beta
-  updateSection(input: PolicyUpdateSectionInput!): PolicySectionMutationPayload! @beta
+  addRule(input: DynamicIpAllocationAddRuleInput!): DynamicIpAllocationRuleMutationPayload!
+  addSection(input: PolicyAddSectionInput!): PolicySectionMutationPayload!
+  createPolicyRevision(input: PolicyCreateRevisionInput!): DynamicIpAllocationPolicyMutationPayload!
+  discardPolicyRevision(input: PolicyDiscardRevisionInput): DynamicIpAllocationPolicyMutationPayload!
+  moveRule(input: PolicyMoveRuleInput!): DynamicIpAllocationRuleMutationPayload!
+  moveSection(input: PolicyMoveSectionInput!): PolicySectionMutationPayload!
+  publishPolicyRevision(input: PolicyPublishRevisionInput): DynamicIpAllocationPolicyMutationPayload!
+  removeRule(input: DynamicIpAllocationRemoveRuleInput!): DynamicIpAllocationRuleMutationPayload!
+  removeSection(input: PolicyRemoveSectionInput!): PolicySectionMutationPayload!
+  updatePolicy(input: DynamicIpAllocationPolicyUpdateInput!): DynamicIpAllocationPolicyMutationPayload!
+  updateRule(input: DynamicIpAllocationUpdateRuleInput!): DynamicIpAllocationRuleMutationPayload!
+  updateSection(input: PolicyUpdateSectionInput!): PolicySectionMutationPayload!
 }
 
 type DynamicIpAllocationPolicyQueries {
-  policy(input: DynamicIpAllocationPolicyInput): DynamicIpAllocationPolicy! @beta
-  revisions: PolicyRevisionsPayload @beta
+  policy(input: DynamicIpAllocationPolicyInput): DynamicIpAllocationPolicy!
+  revisions: PolicyRevisionsPayload
 }
 
 type DynamicIpAllocationRange {
@@ -2475,6 +2474,10 @@ type EnableServiceForManagedAccountPayload {
 """ Response payload for the enableUser mutation. """
 type EnableUserPayload {
   users: [User!]!
+}
+
+type EncryptKeytabFilePayload {
+  encryptedFile: String!
 }
 
 """ End Point Protection (EPP) license details """
@@ -3384,27 +3387,27 @@ type InternetFirewallPolicyMutationPayload implements IPolicyMutationPayload {
 
 """ The Internet firewall Policy information returned to the caller in the API response. """
 type InternetFirewallPolicyMutations {
-  addRule(input: InternetFirewallAddRuleInput!): InternetFirewallRuleMutationPayload! @beta
-  addSection(input: PolicyAddSectionInput!): PolicySectionMutationPayload! @beta
-  addSubPolicy(input: InternetFirewallAddSubPolicyInput!): InternetFirewallAddSubPolicyMutationPayload! @beta
-  createPolicyRevision(input: PolicyCreateRevisionInput!): InternetFirewallPolicyMutationPayload! @beta
-  discardPolicyRevision(input: PolicyDiscardRevisionInput): InternetFirewallPolicyMutationPayload! @beta
-  moveRule(input: PolicyMoveRuleInput!): InternetFirewallRuleMutationPayload! @beta
-  moveSection(input: PolicyMoveSectionInput!): PolicySectionMutationPayload! @beta
-  publishPolicyRevision(input: PolicyPublishRevisionInput): InternetFirewallPolicyMutationPayload! @beta
-  removeRule(input: InternetFirewallRemoveRuleInput!): InternetFirewallRuleMutationPayload! @beta
-  removeSection(input: PolicyRemoveSectionInput!): PolicySectionMutationPayload! @beta
+  addRule(input: InternetFirewallAddRuleInput!): InternetFirewallRuleMutationPayload!
+  addSection(input: PolicyAddSectionInput!): PolicySectionMutationPayload!
+  addSubPolicy(input: InternetFirewallAddSubPolicyInput!): InternetFirewallAddSubPolicyMutationPayload!
+  createPolicyRevision(input: PolicyCreateRevisionInput!): InternetFirewallPolicyMutationPayload!
+  discardPolicyRevision(input: PolicyDiscardRevisionInput): InternetFirewallPolicyMutationPayload!
+  moveRule(input: PolicyMoveRuleInput!): InternetFirewallRuleMutationPayload!
+  moveSection(input: PolicyMoveSectionInput!): PolicySectionMutationPayload!
+  publishPolicyRevision(input: PolicyPublishRevisionInput): InternetFirewallPolicyMutationPayload!
+  removeRule(input: InternetFirewallRemoveRuleInput!): InternetFirewallRuleMutationPayload!
+  removeSection(input: PolicyRemoveSectionInput!): PolicySectionMutationPayload!
   reorderPolicy(input: PolicyReorderInput!): InternetFirewallPolicyMutationPayload! @beta
-  removeSubPolicy(input: InternetFirewallRemoveSubPolicyInput!): InternetFirewallRemoveSubPolicyMutationPayload! @beta
-  updatePolicy(input: InternetFirewallPolicyUpdateInput!): InternetFirewallPolicyMutationPayload! @beta
-  updateRule(input: InternetFirewallUpdateRuleInput!): InternetFirewallRuleMutationPayload! @beta
-  updateSection(input: PolicyUpdateSectionInput!): PolicySectionMutationPayload! @beta
+  removeSubPolicy(input: InternetFirewallRemoveSubPolicyInput!): InternetFirewallRemoveSubPolicyMutationPayload!
+  updatePolicy(input: InternetFirewallPolicyUpdateInput!): InternetFirewallPolicyMutationPayload!
+  updateRule(input: InternetFirewallUpdateRuleInput!): InternetFirewallRuleMutationPayload!
+  updateSection(input: PolicyUpdateSectionInput!): PolicySectionMutationPayload!
 }
 
 type InternetFirewallPolicyQueries {
-  policy(input: InternetFirewallPolicyInput): InternetFirewallPolicy! @beta
-  policyList(input: InternetFirewallPolicyListInput! = {sort:{name:{direction:ASC,priority:1},policyLevel:{direction:ASC,priority:2}},paging:{limit:100,from:0}}): InternetFirewallPolicyListPayload! @beta
-  revisions: PolicyRevisionsPayload @beta
+  policy(input: InternetFirewallPolicyInput): InternetFirewallPolicy!
+  policyList(input: InternetFirewallPolicyListInput! = {sort:{name:{direction:ASC,priority:1},policyLevel:{direction:ASC,priority:2}},paging:{limit:100,from:0}}): InternetFirewallPolicyListPayload!
+  revisions: PolicyRevisionsPayload
 }
 
 type InternetFirewallPolicyRef implements ObjectRef & PolicyRef {
@@ -4182,6 +4185,12 @@ type NetworkConfigDhcpOptionListPayload {
   paging: PageInfo!
 }
 
+""" A reference to an existing DHCP profile. """
+type NetworkConfigDhcpProfileRef implements ObjectRef {
+  id: ID!
+  name: String!
+}
+
 """ DHCP read operations for the account. """
 type NetworkConfigDhcpQueries {
   option(input: NetworkConfigDhcpOptionRefInput!): NetworkConfigDhcpOption @rollout @beta
@@ -4341,6 +4350,12 @@ type NetworkConfigDnsServerSetListPayload {
   paging: PageInfo!
 }
 
+""" A reference to an existing DNS server set. """
+type NetworkConfigDnsServerSetRef implements ObjectRef {
+  id: ID!
+  name: String!
+}
+
 """ Result of replacing the DNS forwarding-rule collection. """
 type NetworkConfigDnsSetForwardingRulePayload {
   forwardingRule: [NetworkConfigDnsForwardingRule!]!
@@ -4386,6 +4401,12 @@ type NetworkConfigDnsSuffixSetListPayload {
   paging: PageInfo!
 }
 
+""" A reference to an existing DNS suffix set. """
+type NetworkConfigDnsSuffixSetRef implements ObjectRef {
+  id: ID!
+  name: String!
+}
+
 """ Result of updating DNS forwarding rules. """
 type NetworkConfigDnsUpdateForwardingRulePayload {
   forwardingRule: [NetworkConfigDnsForwardingRule!]!
@@ -4421,6 +4442,12 @@ type NetworkConfigMutations {
 type NetworkConfigQueries {
   dhcp: NetworkConfigDhcpQueries!
   dns: NetworkConfigDnsQueries!
+}
+
+""" A reference to an existing SNMP profile. """
+type NetworkConfigSnmpProfileRef implements ObjectRef {
+  id: ID!
+  name: String!
 }
 
 """ A reference identifying the NetworkInterface object. ID: Unique NetworkInterface Identifier, Name: The NetworkInterface Name """
@@ -4749,42 +4776,44 @@ type PolicyMutationError {
 }
 
 type PolicyMutations {
-  antiMalwareFileHash(input: AntiMalwareFileHashPolicyMutationInput): AntiMalwareFileHashPolicyMutations
-  appTenantRestriction(input: AppTenantRestrictionPolicyMutationInput): AppTenantRestrictionPolicyMutations
-  applicationControl(input: ApplicationControlPolicyMutationInput): ApplicationControlPolicyMutations
-  clientConnectivity(input: ClientConnectivityPolicyMutationInput): ClientConnectivityPolicyMutations
-  dynamicIpAllocation(input: DynamicIpAllocationPolicyMutationInput): DynamicIpAllocationPolicyMutations
-  internetFirewall(input: InternetFirewallPolicyMutationInput): InternetFirewallPolicyMutations
-  privateAccess(input: PrivateAccessPolicyMutationInput): PrivateAccessPolicyMutations
-  remotePortFwd(input: RemotePortFwdPolicyMutationInput): RemotePortFwdPolicyMutations
-  socketBypass(input: SocketBypassPolicyMutationInput): SocketBypassPolicyMutations
-  socketLan(input: SocketLanPolicyMutationInput): SocketLanPolicyMutations
-  splitTunnel(input: SplitTunnelPolicyMutationInput): SplitTunnelPolicyMutations
-  terminalServer(input: TerminalServerPolicyMutationInput): TerminalServerPolicyMutations
-  tlsInspect(input: TlsInspectPolicyMutationInput): TlsInspectPolicyMutations
-  wanFirewall(input: WanFirewallPolicyMutationInput): WanFirewallPolicyMutations
-  wanNetwork(input: WanNetworkPolicyMutationInput): WanNetworkPolicyMutations
-  ztnaAlwaysOn(input: ZtnaAlwaysOnPolicyMutationInput): ZtnaAlwaysOnPolicyMutations
+  antiMalwareFileHash(input: AntiMalwareFileHashPolicyMutationInput): AntiMalwareFileHashPolicyMutations @beta
+  appTenantRestriction(input: AppTenantRestrictionPolicyMutationInput): AppTenantRestrictionPolicyMutations @beta
+  applicationControl(input: ApplicationControlPolicyMutationInput): ApplicationControlPolicyMutations @beta
+  clientConnectivity(input: ClientConnectivityPolicyMutationInput): ClientConnectivityPolicyMutations @beta
+  dynamicIpAllocation(input: DynamicIpAllocationPolicyMutationInput): DynamicIpAllocationPolicyMutations @beta
+  internetFirewall(input: InternetFirewallPolicyMutationInput): InternetFirewallPolicyMutations @beta
+  privateAccess(input: PrivateAccessPolicyMutationInput): PrivateAccessPolicyMutations @beta
+  remotePortFwd(input: RemotePortFwdPolicyMutationInput): RemotePortFwdPolicyMutations @beta
+  siteWebProxy(input: SiteWebProxyPolicyMutationInput): SiteWebProxyPolicyMutations @beta
+  socketBypass(input: SocketBypassPolicyMutationInput): SocketBypassPolicyMutations @beta
+  socketLan(input: SocketLanPolicyMutationInput): SocketLanPolicyMutations @beta
+  splitTunnel(input: SplitTunnelPolicyMutationInput): SplitTunnelPolicyMutations @beta
+  terminalServer(input: TerminalServerPolicyMutationInput): TerminalServerPolicyMutations @beta
+  tlsInspect(input: TlsInspectPolicyMutationInput): TlsInspectPolicyMutations @beta
+  wanFirewall(input: WanFirewallPolicyMutationInput): WanFirewallPolicyMutations @beta
+  wanNetwork(input: WanNetworkPolicyMutationInput): WanNetworkPolicyMutations @beta
+  ztnaAlwaysOn(input: ZtnaAlwaysOnPolicyMutationInput): ZtnaAlwaysOnPolicyMutations @beta
 }
 
 """ policies which configuration can be read with query APIs. """
 type PolicyQueries {
-  antiMalwareFileHash: AntiMalwareFileHashPolicyQueries
-  appTenantRestriction: AppTenantRestrictionPolicyQueries
-  applicationControl: ApplicationControlPolicyQueries
-  clientConnectivity: ClientConnectivityPolicyQueries
-  dynamicIpAllocation: DynamicIpAllocationPolicyQueries
-  internetFirewall: InternetFirewallPolicyQueries
-  privateAccess: PrivateAccessPolicyQueries
-  remotePortFwd: RemotePortFwdPolicyQueries
-  socketBypass: SocketBypassPolicyQueries
-  socketLan: SocketLanPolicyQueries
-  splitTunnel: SplitTunnelPolicyQueries
-  terminalServer: TerminalServerPolicyQueries
-  tlsInspect: TlsInspectPolicyQueries
-  wanFirewall: WanFirewallPolicyQueries
-  wanNetwork: WanNetworkPolicyQueries
-  ztnaAlwaysOn: ZtnaAlwaysOnPolicyQueries
+  antiMalwareFileHash: AntiMalwareFileHashPolicyQueries @beta
+  appTenantRestriction: AppTenantRestrictionPolicyQueries @beta
+  applicationControl: ApplicationControlPolicyQueries @beta
+  clientConnectivity: ClientConnectivityPolicyQueries @beta
+  dynamicIpAllocation: DynamicIpAllocationPolicyQueries @beta
+  internetFirewall: InternetFirewallPolicyQueries @beta
+  privateAccess: PrivateAccessPolicyQueries @beta
+  remotePortFwd: RemotePortFwdPolicyQueries @beta
+  siteWebProxy: SiteWebProxyPolicyQueries @beta
+  socketBypass: SocketBypassPolicyQueries @beta
+  socketLan: SocketLanPolicyQueries @beta
+  splitTunnel: SplitTunnelPolicyQueries @beta
+  terminalServer: TerminalServerPolicyQueries @beta
+  tlsInspect: TlsInspectPolicyQueries @beta
+  wanFirewall: WanFirewallPolicyQueries @beta
+  wanNetwork: WanNetworkPolicyQueries @beta
+  ztnaAlwaysOn: ZtnaAlwaysOnPolicyQueries @beta
 }
 
 """ Returns data about the policy revision, such as when the change was made, how many rules were changed, etc. """
@@ -5038,23 +5067,23 @@ type PrivateAccessPolicyMutationPayload implements IPolicyMutationPayload {
 }
 
 type PrivateAccessPolicyMutations {
-  addRule(input: PrivateAccessAddRuleInput!): PrivateAccessRuleMutationPayload! @beta
-  addSection(input: PolicyAddSectionInput!): PolicySectionMutationPayload! @beta
-  createPolicyRevision(input: PolicyCreateRevisionInput!): PrivateAccessPolicyMutationPayload! @beta
-  discardPolicyRevision(input: PolicyDiscardRevisionInput): PrivateAccessPolicyMutationPayload! @beta
-  moveRule(input: PolicyMoveRuleInput!): PrivateAccessRuleMutationPayload! @beta
-  moveSection(input: PolicyMoveSectionInput!): PolicySectionMutationPayload! @beta
-  publishPolicyRevision(input: PolicyPublishRevisionInput): PrivateAccessPolicyMutationPayload! @beta
-  removeRule(input: PrivateAccessRemoveRuleInput!): PrivateAccessRuleMutationPayload! @beta
-  removeSection(input: PolicyRemoveSectionInput!): PolicySectionMutationPayload! @beta
-  updatePolicy(input: PrivateAccessPolicyUpdateInput!): PrivateAccessPolicyMutationPayload! @beta
-  updateRule(input: PrivateAccessUpdateRuleInput!): PrivateAccessRuleMutationPayload! @beta
-  updateSection(input: PolicyUpdateSectionInput!): PolicySectionMutationPayload! @beta
+  addRule(input: PrivateAccessAddRuleInput!): PrivateAccessRuleMutationPayload!
+  addSection(input: PolicyAddSectionInput!): PolicySectionMutationPayload!
+  createPolicyRevision(input: PolicyCreateRevisionInput!): PrivateAccessPolicyMutationPayload!
+  discardPolicyRevision(input: PolicyDiscardRevisionInput): PrivateAccessPolicyMutationPayload!
+  moveRule(input: PolicyMoveRuleInput!): PrivateAccessRuleMutationPayload!
+  moveSection(input: PolicyMoveSectionInput!): PolicySectionMutationPayload!
+  publishPolicyRevision(input: PolicyPublishRevisionInput): PrivateAccessPolicyMutationPayload!
+  removeRule(input: PrivateAccessRemoveRuleInput!): PrivateAccessRuleMutationPayload!
+  removeSection(input: PolicyRemoveSectionInput!): PolicySectionMutationPayload!
+  updatePolicy(input: PrivateAccessPolicyUpdateInput!): PrivateAccessPolicyMutationPayload!
+  updateRule(input: PrivateAccessUpdateRuleInput!): PrivateAccessRuleMutationPayload!
+  updateSection(input: PolicyUpdateSectionInput!): PolicySectionMutationPayload!
 }
 
 type PrivateAccessPolicyQueries {
-  policy(input: PrivateAccessPolicyInput): PrivateAccessPolicy! @beta
-  revisions: PolicyRevisionsPayload @beta
+  policy(input: PrivateAccessPolicyInput): PrivateAccessPolicy!
+  revisions: PolicyRevisionsPayload
 }
 
 type PrivateAccessPolicySource {
@@ -5244,23 +5273,23 @@ type RemotePortFwdPolicyMutationPayload implements IPolicyMutationPayload {
 
 """ The Remote Port Forwarding Policy information returned to the caller in the API response. """
 type RemotePortFwdPolicyMutations {
-  addRule(input: RemotePortFwdAddRuleInput!): RemotePortFwdRuleMutationPayload! @beta
-  addSection(input: PolicyAddSectionInput!): PolicySectionMutationPayload! @beta
-  createPolicyRevision(input: PolicyCreateRevisionInput!): RemotePortFwdPolicyMutationPayload! @beta
-  discardPolicyRevision(input: PolicyDiscardRevisionInput): RemotePortFwdPolicyMutationPayload! @beta
-  moveRule(input: PolicyMoveRuleInput!): RemotePortFwdRuleMutationPayload! @beta
-  moveSection(input: PolicyMoveSectionInput!): PolicySectionMutationPayload! @beta
-  publishPolicyRevision(input: PolicyPublishRevisionInput): RemotePortFwdPolicyMutationPayload! @beta
-  removeRule(input: RemotePortFwdRemoveRuleInput!): RemotePortFwdRuleMutationPayload! @beta
-  removeSection(input: PolicyRemoveSectionInput!): PolicySectionMutationPayload! @beta
-  updatePolicy(input: RemotePortFwdPolicyUpdateInput!): RemotePortFwdPolicyMutationPayload! @beta
-  updateRule(input: RemotePortFwdUpdateRuleInput!): RemotePortFwdRuleMutationPayload! @beta
-  updateSection(input: PolicyUpdateSectionInput!): PolicySectionMutationPayload! @beta
+  addRule(input: RemotePortFwdAddRuleInput!): RemotePortFwdRuleMutationPayload!
+  addSection(input: PolicyAddSectionInput!): PolicySectionMutationPayload!
+  createPolicyRevision(input: PolicyCreateRevisionInput!): RemotePortFwdPolicyMutationPayload!
+  discardPolicyRevision(input: PolicyDiscardRevisionInput): RemotePortFwdPolicyMutationPayload!
+  moveRule(input: PolicyMoveRuleInput!): RemotePortFwdRuleMutationPayload!
+  moveSection(input: PolicyMoveSectionInput!): PolicySectionMutationPayload!
+  publishPolicyRevision(input: PolicyPublishRevisionInput): RemotePortFwdPolicyMutationPayload!
+  removeRule(input: RemotePortFwdRemoveRuleInput!): RemotePortFwdRuleMutationPayload!
+  removeSection(input: PolicyRemoveSectionInput!): PolicySectionMutationPayload!
+  updatePolicy(input: RemotePortFwdPolicyUpdateInput!): RemotePortFwdPolicyMutationPayload!
+  updateRule(input: RemotePortFwdUpdateRuleInput!): RemotePortFwdRuleMutationPayload!
+  updateSection(input: PolicyUpdateSectionInput!): PolicySectionMutationPayload!
 }
 
 type RemotePortFwdPolicyQueries {
-  policy(input: RemotePortFwdPolicyInput): RemotePortFwdPolicy! @beta
-  revisions: PolicyRevisionsPayload @beta
+  policy(input: RemotePortFwdPolicyInput): RemotePortFwdPolicy!
+  revisions: PolicyRevisionsPayload
 }
 
 type RemotePortFwdRemoteIps {
@@ -5821,6 +5850,134 @@ type SiteUpgradeInfo {
   targetVersion: String!
 }
 
+""" Authentication configuration for the web proxy, including any required protocol-specific settings. """
+type SiteWebProxyAuthenticationConfig {
+  kerberosConfig: SiteWebProxyKerberosConfig
+  method: SiteWebProxyAuthMethod
+}
+
+""" Destination criteria matched by a web proxy traffic rule. To specify 'ANY' destination, an empty list must be provided for each match criteria field (e.g. fqdn: [], ip: []). """
+type SiteWebProxyDestination {
+  domain: [Domain!]!
+  fqdn: [Fqdn!]!
+  ip: [IPAddress!]!
+}
+
+""" Kerberos authentication settings for the web proxy. """
+type SiteWebProxyKerberosConfig {
+  encryptedKeytab: String
+  isEnabled: Boolean!
+}
+
+type SiteWebProxyPolicy implements IPolicy {
+  audit: PolicyAudit
+  enabled: Boolean!
+  revision: PolicyRevision
+  rules: [SiteWebProxyRulePayload!]!
+  sections: [PolicySectionPayload!]!
+}
+
+type SiteWebProxyPolicyMutationPayload implements IPolicyMutationPayload {
+  errors: [PolicyMutationError!]!
+  policy: SiteWebProxyPolicy
+  status: PolicyMutationStatus!
+}
+
+type SiteWebProxyPolicyMutations {
+  addRule(input: SiteWebProxyAddRuleInput!): SiteWebProxyRuleMutationPayload!
+  addSection(input: PolicyAddSectionInput!): PolicySectionMutationPayload!
+  createPolicyRevision(input: PolicyCreateRevisionInput!): SiteWebProxyPolicyMutationPayload!
+  discardPolicyRevision(input: PolicyDiscardRevisionInput): SiteWebProxyPolicyMutationPayload!
+  moveRule(input: PolicyMoveRuleInput!): SiteWebProxyRuleMutationPayload!
+  moveSection(input: PolicyMoveSectionInput!): PolicySectionMutationPayload!
+  publishPolicyRevision(input: PolicyPublishRevisionInput): SiteWebProxyPolicyMutationPayload!
+  removeRule(input: SiteWebProxyRemoveRuleInput!): SiteWebProxyRuleMutationPayload!
+  removeSection(input: PolicyRemoveSectionInput!): PolicySectionMutationPayload!
+  updatePolicy(input: SiteWebProxyPolicyUpdateInput!): SiteWebProxyPolicyMutationPayload!
+  updateRule(input: SiteWebProxyUpdateRuleInput!): SiteWebProxyRuleMutationPayload!
+  updateSection(input: PolicyUpdateSectionInput!): PolicySectionMutationPayload!
+  webProxyTraffic: SiteWebProxyTrafficPolicyMutations!
+}
+
+type SiteWebProxyPolicyQueries {
+  policy(input: SiteWebProxyPolicyInput): SiteWebProxyPolicy!
+  revisions: PolicyRevisionsPayload
+}
+
+type SiteWebProxyRule implements IPolicyRule {
+  associatedSite: [SiteRef!]!
+  authenticationConfig: SiteWebProxyAuthenticationConfig!
+  description: String!
+  enabled: Boolean!
+  fqdn: Fqdn!
+  id: ID!
+  index: Int!
+  name: String!
+  port: Port!
+  section: PolicySectionInfo!
+  shouldAssociateWithAllSites: Boolean!
+  webProxyTraffic: [SiteWebProxyTrafficRulePayload!]!
+}
+
+type SiteWebProxyRuleMutationPayload implements IPolicyRuleMutationPayload {
+  errors: [PolicyMutationError!]!
+  revision: PolicyRevision
+  rule: SiteWebProxyRulePayload
+  status: PolicyMutationStatus!
+}
+
+type SiteWebProxyRulePayload implements IPolicyRulePayload {
+  audit: PolicyElementAudit!
+  metadata: PolicyElementMetadata
+  properties: [PolicyElementPropertiesEnum!]!
+  rule: SiteWebProxyRule!
+}
+
+""" Source criteria matched by a web proxy traffic rule. To specify 'ANY' source, an empty list must be provided for each match criteria field (e.g. ip: [], site: [], etc...). """
+type SiteWebProxySource {
+  globalIpRange: [GlobalIpRangeRef!]!
+  group: [GroupRef!]!
+  ip: [IPAddress!]!
+  ipRange: [IpAddressRange!]!
+  networkInterface: [NetworkInterfaceRef!]!
+  site: [SiteRef!]!
+  siteNetworkSubnet: [SiteNetworkSubnetRef!]!
+  subnet: [NetworkSubnet!]!
+}
+
+type SiteWebProxyTrafficPolicyMutations {
+  addRule(input: SiteWebProxyTrafficAddRuleInput!): SiteWebProxyTrafficRuleMutationPayload!
+  moveRule(input: PolicyMoveSubRuleInput!): SiteWebProxyTrafficRuleMutationPayload!
+  removeRule(input: SiteWebProxyTrafficRemoveRuleInput!): SiteWebProxyTrafficRuleMutationPayload!
+  updateRule(input: SiteWebProxyTrafficUpdateRuleInput!): SiteWebProxyTrafficRuleMutationPayload!
+}
+
+type SiteWebProxyTrafficRule implements IPolicyRule {
+  action: SiteWebProxyAction!
+  description: String!
+  destination: SiteWebProxyDestination!
+  enabled: Boolean!
+  id: ID!
+  index: Int!
+  name: String!
+  section: PolicySectionInfo
+  source: SiteWebProxySource!
+}
+
+type SiteWebProxyTrafficRuleMutationPayload implements IPolicyRuleMutationPayload {
+  errors: [PolicyMutationError!]!
+  revision: PolicyRevision
+  rule: SiteWebProxyTrafficRulePayload
+  status: PolicyMutationStatus!
+}
+
+type SiteWebProxyTrafficRulePayload implements IPolicyRulePayload {
+  audit: PolicyElementAudit!
+  metadata: PolicyElementMetadata
+  properties: [PolicyElementPropertiesEnum!]!
+  rule: SiteWebProxyTrafficRule!
+}
+
 type SiteWorkingHours {
   fromTimeMinuteOffset: Int
   override: Boolean!
@@ -5873,24 +6030,24 @@ type SocketBypassPolicyMutationPayload implements IPolicyMutationPayload {
 }
 
 type SocketBypassPolicyMutations {
-  addRule(input: SocketBypassAddRuleInput!): SocketBypassRuleMutationPayload! @beta
-  addSection(input: PolicyAddSectionInput!): PolicySectionMutationPayload! @beta
-  createPolicyRevision(input: PolicyCreateRevisionInput!): SocketBypassPolicyMutationPayload! @beta
-  discardPolicyRevision(input: PolicyDiscardRevisionInput): SocketBypassPolicyMutationPayload! @beta
-  moveRule(input: PolicyMoveRuleInput!): SocketBypassRuleMutationPayload! @beta
-  moveSection(input: PolicyMoveSectionInput!): PolicySectionMutationPayload! @beta
-  publishPolicyRevision(input: PolicyPublishRevisionInput): SocketBypassPolicyMutationPayload! @beta
-  removeRule(input: SocketBypassRemoveRuleInput!): SocketBypassRuleMutationPayload! @beta
-  removeSection(input: PolicyRemoveSectionInput!): PolicySectionMutationPayload! @beta
+  addRule(input: SocketBypassAddRuleInput!): SocketBypassRuleMutationPayload!
+  addSection(input: PolicyAddSectionInput!): PolicySectionMutationPayload!
+  createPolicyRevision(input: PolicyCreateRevisionInput!): SocketBypassPolicyMutationPayload!
+  discardPolicyRevision(input: PolicyDiscardRevisionInput): SocketBypassPolicyMutationPayload!
+  moveRule(input: PolicyMoveRuleInput!): SocketBypassRuleMutationPayload!
+  moveSection(input: PolicyMoveSectionInput!): PolicySectionMutationPayload!
+  publishPolicyRevision(input: PolicyPublishRevisionInput): SocketBypassPolicyMutationPayload!
+  removeRule(input: SocketBypassRemoveRuleInput!): SocketBypassRuleMutationPayload!
+  removeSection(input: PolicyRemoveSectionInput!): PolicySectionMutationPayload!
   reorderPolicy(input: PolicyReorderInput!): SocketBypassPolicyMutationPayload! @beta
-  updatePolicy(input: SocketBypassPolicyUpdateInput!): SocketBypassPolicyMutationPayload! @beta
-  updateRule(input: SocketBypassUpdateRuleInput!): SocketBypassRuleMutationPayload! @beta
-  updateSection(input: PolicyUpdateSectionInput!): PolicySectionMutationPayload! @beta
+  updatePolicy(input: SocketBypassPolicyUpdateInput!): SocketBypassPolicyMutationPayload!
+  updateRule(input: SocketBypassUpdateRuleInput!): SocketBypassRuleMutationPayload!
+  updateSection(input: PolicyUpdateSectionInput!): PolicySectionMutationPayload!
 }
 
 type SocketBypassPolicyQueries {
-  policy(input: SocketBypassPolicyInput): SocketBypassPolicy! @beta
-  revisions: PolicyRevisionsPayload @beta
+  policy(input: SocketBypassPolicyInput): SocketBypassPolicy!
+  revisions: PolicyRevisionsPayload
 }
 
 type SocketBypassRule implements IPolicyRule {
@@ -6055,10 +6212,10 @@ type SocketLanFirewallDestination {
 }
 
 type SocketLanFirewallPolicyMutations {
-  addRule(input: SocketLanFirewallAddRuleInput!): SocketLanFirewallRuleMutationPayload! @beta
-  moveRule(input: PolicyMoveSubRuleInput!): SocketLanFirewallRuleMutationPayload! @beta
-  removeRule(input: SocketLanFirewallRemoveRuleInput!): SocketLanFirewallRuleMutationPayload! @beta
-  updateRule(input: SocketLanFirewallUpdateRuleInput!): SocketLanFirewallRuleMutationPayload! @beta
+  addRule(input: SocketLanFirewallAddRuleInput!): SocketLanFirewallRuleMutationPayload!
+  moveRule(input: PolicyMoveSubRuleInput!): SocketLanFirewallRuleMutationPayload!
+  removeRule(input: SocketLanFirewallRemoveRuleInput!): SocketLanFirewallRuleMutationPayload!
+  updateRule(input: SocketLanFirewallUpdateRuleInput!): SocketLanFirewallRuleMutationPayload!
 }
 
 """ A reference to a SocketLAN Firewall sub-policy. Sub-model rules are always POLICY_RULE type; this field is present for PPS RBAC field compatibility. """
@@ -6164,28 +6321,28 @@ type SocketLanPolicyMutationPayload implements IPolicyMutationPayload {
 }
 
 type SocketLanPolicyMutations {
-  addRule(input: SocketLanAddRuleInput!): SocketLanRuleMutationPayload! @beta
-  addSection(input: PolicyAddSectionInput!): PolicySectionMutationPayload! @beta
-  addSubPolicy(input: SocketLanAddSubPolicyInput!): SocketLanAddSubPolicyMutationPayload! @beta
-  createPolicyRevision(input: PolicyCreateRevisionInput!): SocketLanPolicyMutationPayload! @beta
-  discardPolicyRevision(input: PolicyDiscardRevisionInput): SocketLanPolicyMutationPayload! @beta
+  addRule(input: SocketLanAddRuleInput!): SocketLanRuleMutationPayload!
+  addSection(input: PolicyAddSectionInput!): PolicySectionMutationPayload!
+  addSubPolicy(input: SocketLanAddSubPolicyInput!): SocketLanAddSubPolicyMutationPayload!
+  createPolicyRevision(input: PolicyCreateRevisionInput!): SocketLanPolicyMutationPayload!
+  discardPolicyRevision(input: PolicyDiscardRevisionInput): SocketLanPolicyMutationPayload!
   firewall: SocketLanFirewallPolicyMutations!
-  moveRule(input: PolicyMoveRuleInput!): SocketLanRuleMutationPayload! @beta
-  moveSection(input: PolicyMoveSectionInput!): PolicySectionMutationPayload! @beta
-  publishPolicyRevision(input: PolicyPublishRevisionInput): SocketLanPolicyMutationPayload! @beta
-  removeRule(input: SocketLanRemoveRuleInput!): SocketLanRuleMutationPayload! @beta
-  removeSection(input: PolicyRemoveSectionInput!): PolicySectionMutationPayload! @beta
-  removeSubPolicy(input: SocketLanRemoveSubPolicyInput!): SocketLanRemoveSubPolicyMutationPayload! @beta
+  moveRule(input: PolicyMoveRuleInput!): SocketLanRuleMutationPayload!
+  moveSection(input: PolicyMoveSectionInput!): PolicySectionMutationPayload!
+  publishPolicyRevision(input: PolicyPublishRevisionInput): SocketLanPolicyMutationPayload!
+  removeRule(input: SocketLanRemoveRuleInput!): SocketLanRuleMutationPayload!
+  removeSection(input: PolicyRemoveSectionInput!): PolicySectionMutationPayload!
+  removeSubPolicy(input: SocketLanRemoveSubPolicyInput!): SocketLanRemoveSubPolicyMutationPayload!
   reorderPolicy(input: PolicyReorderInput!): SocketLanPolicyMutationPayload! @beta
-  updatePolicy(input: SocketLanPolicyUpdateInput!): SocketLanPolicyMutationPayload! @beta
-  updateRule(input: SocketLanUpdateRuleInput!): SocketLanRuleMutationPayload! @beta
-  updateSection(input: PolicyUpdateSectionInput!): PolicySectionMutationPayload! @beta
+  updatePolicy(input: SocketLanPolicyUpdateInput!): SocketLanPolicyMutationPayload!
+  updateRule(input: SocketLanUpdateRuleInput!): SocketLanRuleMutationPayload!
+  updateSection(input: PolicyUpdateSectionInput!): PolicySectionMutationPayload!
 }
 
 type SocketLanPolicyQueries {
-  policy(input: SocketLanPolicyInput): SocketLanPolicy! @beta
-  policyList(input: SocketLanPolicyListInput! = {sort:{name:{direction:ASC,priority:1},policyLevel:{direction:ASC,priority:2}},paging:{limit:100,from:0}}): SocketLanPolicyListPayload! @beta
-  revisions: PolicyRevisionsPayload @beta
+  policy(input: SocketLanPolicyInput): SocketLanPolicy!
+  policyList(input: SocketLanPolicyListInput! = {sort:{name:{direction:ASC,priority:1},policyLevel:{direction:ASC,priority:2}},paging:{limit:100,from:0}}): SocketLanPolicyListPayload!
+  revisions: PolicyRevisionsPayload
 }
 
 type SocketLanPolicyRef implements ObjectRef & PolicyRef {
@@ -6329,23 +6486,23 @@ type SplitTunnelPolicyMutationPayload implements IPolicyMutationPayload {
 }
 
 type SplitTunnelPolicyMutations {
-  addRule(input: SplitTunnelAddRuleInput!): SplitTunnelRuleMutationPayload! @beta
-  addSection(input: PolicyAddSectionInput!): PolicySectionMutationPayload! @beta
-  createPolicyRevision(input: PolicyCreateRevisionInput!): SplitTunnelPolicyMutationPayload! @beta
-  discardPolicyRevision(input: PolicyDiscardRevisionInput): SplitTunnelPolicyMutationPayload! @beta
-  moveRule(input: PolicyMoveRuleInput!): SplitTunnelRuleMutationPayload! @beta
-  moveSection(input: PolicyMoveSectionInput!): PolicySectionMutationPayload! @beta
-  publishPolicyRevision(input: PolicyPublishRevisionInput): SplitTunnelPolicyMutationPayload! @beta
-  removeRule(input: SplitTunnelRemoveRuleInput!): SplitTunnelRuleMutationPayload! @beta
-  removeSection(input: PolicyRemoveSectionInput!): PolicySectionMutationPayload! @beta
-  updatePolicy(input: SplitTunnelPolicyUpdateInput!): SplitTunnelPolicyMutationPayload! @beta
-  updateRule(input: SplitTunnelUpdateRuleInput!): SplitTunnelRuleMutationPayload! @beta
-  updateSection(input: PolicyUpdateSectionInput!): PolicySectionMutationPayload! @beta
+  addRule(input: SplitTunnelAddRuleInput!): SplitTunnelRuleMutationPayload!
+  addSection(input: PolicyAddSectionInput!): PolicySectionMutationPayload!
+  createPolicyRevision(input: PolicyCreateRevisionInput!): SplitTunnelPolicyMutationPayload!
+  discardPolicyRevision(input: PolicyDiscardRevisionInput): SplitTunnelPolicyMutationPayload!
+  moveRule(input: PolicyMoveRuleInput!): SplitTunnelRuleMutationPayload!
+  moveSection(input: PolicyMoveSectionInput!): PolicySectionMutationPayload!
+  publishPolicyRevision(input: PolicyPublishRevisionInput): SplitTunnelPolicyMutationPayload!
+  removeRule(input: SplitTunnelRemoveRuleInput!): SplitTunnelRuleMutationPayload!
+  removeSection(input: PolicyRemoveSectionInput!): PolicySectionMutationPayload!
+  updatePolicy(input: SplitTunnelPolicyUpdateInput!): SplitTunnelPolicyMutationPayload!
+  updateRule(input: SplitTunnelUpdateRuleInput!): SplitTunnelRuleMutationPayload!
+  updateSection(input: PolicyUpdateSectionInput!): PolicySectionMutationPayload!
 }
 
 type SplitTunnelPolicyQueries {
-  policy(input: SplitTunnelPolicyInput): SplitTunnelPolicy! @beta
-  revisions: PolicyRevisionsPayload @beta
+  policy(input: SplitTunnelPolicyInput): SplitTunnelPolicy!
+  revisions: PolicyRevisionsPayload
 }
 
 type SplitTunnelRule implements IPolicyRule {
@@ -6522,23 +6679,23 @@ type TerminalServerPolicyMutationPayload implements IPolicyMutationPayload {
 }
 
 type TerminalServerPolicyMutations {
-  addRule(input: TerminalServerAddRuleInput!): TerminalServerRuleMutationPayload! @beta
-  addSection(input: PolicyAddSectionInput!): PolicySectionMutationPayload! @beta
-  createPolicyRevision(input: PolicyCreateRevisionInput!): TerminalServerPolicyMutationPayload! @beta
-  discardPolicyRevision(input: PolicyDiscardRevisionInput): TerminalServerPolicyMutationPayload! @beta
-  moveRule(input: PolicyMoveRuleInput!): TerminalServerRuleMutationPayload! @beta
-  moveSection(input: PolicyMoveSectionInput!): PolicySectionMutationPayload! @beta
-  publishPolicyRevision(input: PolicyPublishRevisionInput): TerminalServerPolicyMutationPayload! @beta
-  removeRule(input: TerminalServerRemoveRuleInput!): TerminalServerRuleMutationPayload! @beta
-  removeSection(input: PolicyRemoveSectionInput!): PolicySectionMutationPayload! @beta
-  updatePolicy(input: TerminalServerPolicyUpdateInput!): TerminalServerPolicyMutationPayload! @beta
-  updateRule(input: TerminalServerUpdateRuleInput!): TerminalServerRuleMutationPayload! @beta
-  updateSection(input: PolicyUpdateSectionInput!): PolicySectionMutationPayload! @beta
+  addRule(input: TerminalServerAddRuleInput!): TerminalServerRuleMutationPayload!
+  addSection(input: PolicyAddSectionInput!): PolicySectionMutationPayload!
+  createPolicyRevision(input: PolicyCreateRevisionInput!): TerminalServerPolicyMutationPayload!
+  discardPolicyRevision(input: PolicyDiscardRevisionInput): TerminalServerPolicyMutationPayload!
+  moveRule(input: PolicyMoveRuleInput!): TerminalServerRuleMutationPayload!
+  moveSection(input: PolicyMoveSectionInput!): PolicySectionMutationPayload!
+  publishPolicyRevision(input: PolicyPublishRevisionInput): TerminalServerPolicyMutationPayload!
+  removeRule(input: TerminalServerRemoveRuleInput!): TerminalServerRuleMutationPayload!
+  removeSection(input: PolicyRemoveSectionInput!): PolicySectionMutationPayload!
+  updatePolicy(input: TerminalServerPolicyUpdateInput!): TerminalServerPolicyMutationPayload!
+  updateRule(input: TerminalServerUpdateRuleInput!): TerminalServerRuleMutationPayload!
+  updateSection(input: PolicyUpdateSectionInput!): PolicySectionMutationPayload!
 }
 
 type TerminalServerPolicyQueries {
-  policy(input: TerminalServerPolicyInput): TerminalServerPolicy! @beta
-  revisions: PolicyRevisionsPayload @beta
+  policy(input: TerminalServerPolicyInput): TerminalServerPolicy!
+  revisions: PolicyRevisionsPayload
 }
 
 type TerminalServerRule implements IPolicyRule {
@@ -6815,23 +6972,23 @@ type TlsInspectPolicyMutationPayload implements IPolicyMutationPayload {
 }
 
 type TlsInspectPolicyMutations {
-  addRule(input: TlsInspectAddRuleInput!): TlsInspectRuleMutationPayload! @beta
-  addSection(input: PolicyAddSectionInput!): PolicySectionMutationPayload! @beta
-  createPolicyRevision(input: PolicyCreateRevisionInput!): TlsInspectPolicyMutationPayload! @beta
-  discardPolicyRevision(input: PolicyDiscardRevisionInput): TlsInspectPolicyMutationPayload! @beta
-  moveRule(input: PolicyMoveRuleInput!): TlsInspectRuleMutationPayload! @beta
-  moveSection(input: PolicyMoveSectionInput!): PolicySectionMutationPayload! @beta
-  publishPolicyRevision(input: PolicyPublishRevisionInput): TlsInspectPolicyMutationPayload! @beta
-  removeRule(input: TlsInspectRemoveRuleInput!): TlsInspectRuleMutationPayload! @beta
-  removeSection(input: PolicyRemoveSectionInput!): PolicySectionMutationPayload! @beta
-  updatePolicy(input: TlsInspectPolicyUpdateInput!): TlsInspectPolicyMutationPayload! @beta
-  updateRule(input: TlsInspectUpdateRuleInput!): TlsInspectRuleMutationPayload! @beta
-  updateSection(input: PolicyUpdateSectionInput!): PolicySectionMutationPayload! @beta
+  addRule(input: TlsInspectAddRuleInput!): TlsInspectRuleMutationPayload!
+  addSection(input: PolicyAddSectionInput!): PolicySectionMutationPayload!
+  createPolicyRevision(input: PolicyCreateRevisionInput!): TlsInspectPolicyMutationPayload!
+  discardPolicyRevision(input: PolicyDiscardRevisionInput): TlsInspectPolicyMutationPayload!
+  moveRule(input: PolicyMoveRuleInput!): TlsInspectRuleMutationPayload!
+  moveSection(input: PolicyMoveSectionInput!): PolicySectionMutationPayload!
+  publishPolicyRevision(input: PolicyPublishRevisionInput): TlsInspectPolicyMutationPayload!
+  removeRule(input: TlsInspectRemoveRuleInput!): TlsInspectRuleMutationPayload!
+  removeSection(input: PolicyRemoveSectionInput!): PolicySectionMutationPayload!
+  updatePolicy(input: TlsInspectPolicyUpdateInput!): TlsInspectPolicyMutationPayload!
+  updateRule(input: TlsInspectUpdateRuleInput!): TlsInspectRuleMutationPayload!
+  updateSection(input: PolicyUpdateSectionInput!): PolicySectionMutationPayload!
 }
 
 type TlsInspectPolicyQueries {
-  policy(input: TlsInspectPolicyInput): TlsInspectPolicy! @beta
-  revisions: PolicyRevisionsPayload @beta
+  policy(input: TlsInspectPolicyInput): TlsInspectPolicy!
+  revisions: PolicyRevisionsPayload
 }
 
 type TlsInspectPolicyRef implements ObjectRef & PolicyRef {
@@ -7334,27 +7491,27 @@ type WanFirewallPolicyMutationPayload implements IPolicyMutationPayload {
 
 """ The Wan Firewall Policy information returned to the caller in the API response. """
 type WanFirewallPolicyMutations {
-  addRule(input: WanFirewallAddRuleInput!): WanFirewallRuleMutationPayload! @beta
-  addSection(input: PolicyAddSectionInput!): PolicySectionMutationPayload! @beta
-  addSubPolicy(input: WanFirewallAddSubPolicyInput!): WanFirewallAddSubPolicyMutationPayload! @beta
-  createPolicyRevision(input: PolicyCreateRevisionInput!): WanFirewallPolicyMutationPayload! @beta
-  discardPolicyRevision(input: PolicyDiscardRevisionInput): WanFirewallPolicyMutationPayload! @beta
-  moveRule(input: PolicyMoveRuleInput!): WanFirewallRuleMutationPayload! @beta
-  moveSection(input: PolicyMoveSectionInput!): PolicySectionMutationPayload! @beta
-  publishPolicyRevision(input: PolicyPublishRevisionInput): WanFirewallPolicyMutationPayload! @beta
-  removeRule(input: WanFirewallRemoveRuleInput!): WanFirewallRuleMutationPayload! @beta
-  removeSection(input: PolicyRemoveSectionInput!): PolicySectionMutationPayload! @beta
-  removeSubPolicy(input: WanFirewallRemoveSubPolicyInput!): WanFirewallRemoveSubPolicyMutationPayload! @beta
+  addRule(input: WanFirewallAddRuleInput!): WanFirewallRuleMutationPayload!
+  addSection(input: PolicyAddSectionInput!): PolicySectionMutationPayload!
+  addSubPolicy(input: WanFirewallAddSubPolicyInput!): WanFirewallAddSubPolicyMutationPayload!
+  createPolicyRevision(input: PolicyCreateRevisionInput!): WanFirewallPolicyMutationPayload!
+  discardPolicyRevision(input: PolicyDiscardRevisionInput): WanFirewallPolicyMutationPayload!
+  moveRule(input: PolicyMoveRuleInput!): WanFirewallRuleMutationPayload!
+  moveSection(input: PolicyMoveSectionInput!): PolicySectionMutationPayload!
+  publishPolicyRevision(input: PolicyPublishRevisionInput): WanFirewallPolicyMutationPayload!
+  removeRule(input: WanFirewallRemoveRuleInput!): WanFirewallRuleMutationPayload!
+  removeSection(input: PolicyRemoveSectionInput!): PolicySectionMutationPayload!
+  removeSubPolicy(input: WanFirewallRemoveSubPolicyInput!): WanFirewallRemoveSubPolicyMutationPayload!
   reorderPolicy(input: PolicyReorderInput!): WanFirewallPolicyMutationPayload! @beta
-  updatePolicy(input: WanFirewallPolicyUpdateInput!): WanFirewallPolicyMutationPayload! @beta
-  updateRule(input: WanFirewallUpdateRuleInput!): WanFirewallRuleMutationPayload! @beta
-  updateSection(input: PolicyUpdateSectionInput!): PolicySectionMutationPayload! @beta
+  updatePolicy(input: WanFirewallPolicyUpdateInput!): WanFirewallPolicyMutationPayload!
+  updateRule(input: WanFirewallUpdateRuleInput!): WanFirewallRuleMutationPayload!
+  updateSection(input: PolicyUpdateSectionInput!): PolicySectionMutationPayload!
 }
 
 type WanFirewallPolicyQueries {
-  policy(input: WanFirewallPolicyInput): WanFirewallPolicy! @beta
-  policyList(input: WanFirewallPolicyListInput! = {sort:{name:{direction:ASC,priority:1},policyLevel:{direction:ASC,priority:2}},paging:{limit:100,from:0}}): WanFirewallPolicyListPayload! @beta
-  revisions: PolicyRevisionsPayload @beta
+  policy(input: WanFirewallPolicyInput): WanFirewallPolicy!
+  policyList(input: WanFirewallPolicyListInput! = {sort:{name:{direction:ASC,priority:1},policyLevel:{direction:ASC,priority:2}},paging:{limit:100,from:0}}): WanFirewallPolicyListPayload!
+  revisions: PolicyRevisionsPayload
 }
 
 type WanFirewallPolicyRef implements ObjectRef & PolicyRef {
@@ -7470,24 +7627,24 @@ type WanNetworkPolicyMutationPayload implements IPolicyMutationPayload {
 }
 
 type WanNetworkPolicyMutations {
-  addRule(input: WanNetworkAddRuleInput!): WanNetworkRuleMutationPayload! @beta
-  addSection(input: PolicyAddSectionInput!): PolicySectionMutationPayload! @beta
-  createPolicyRevision(input: PolicyCreateRevisionInput!): WanNetworkPolicyMutationPayload! @beta
-  discardPolicyRevision(input: PolicyDiscardRevisionInput): WanNetworkPolicyMutationPayload! @beta
-  moveRule(input: PolicyMoveRuleInput!): WanNetworkRuleMutationPayload! @beta
-  moveSection(input: PolicyMoveSectionInput!): PolicySectionMutationPayload! @beta
-  publishPolicyRevision(input: PolicyPublishRevisionInput): WanNetworkPolicyMutationPayload! @beta
-  removeRule(input: WanNetworkRemoveRuleInput!): WanNetworkRuleMutationPayload! @beta
-  removeSection(input: PolicyRemoveSectionInput!): PolicySectionMutationPayload! @beta
+  addRule(input: WanNetworkAddRuleInput!): WanNetworkRuleMutationPayload!
+  addSection(input: PolicyAddSectionInput!): PolicySectionMutationPayload!
+  createPolicyRevision(input: PolicyCreateRevisionInput!): WanNetworkPolicyMutationPayload!
+  discardPolicyRevision(input: PolicyDiscardRevisionInput): WanNetworkPolicyMutationPayload!
+  moveRule(input: PolicyMoveRuleInput!): WanNetworkRuleMutationPayload!
+  moveSection(input: PolicyMoveSectionInput!): PolicySectionMutationPayload!
+  publishPolicyRevision(input: PolicyPublishRevisionInput): WanNetworkPolicyMutationPayload!
+  removeRule(input: WanNetworkRemoveRuleInput!): WanNetworkRuleMutationPayload!
+  removeSection(input: PolicyRemoveSectionInput!): PolicySectionMutationPayload!
   reorderPolicy(input: PolicyReorderInput!): WanNetworkPolicyMutationPayload! @beta
-  updatePolicy(input: WanNetworkPolicyUpdateInput!): WanNetworkPolicyMutationPayload! @beta
-  updateRule(input: WanNetworkUpdateRuleInput!): WanNetworkRuleMutationPayload! @beta
-  updateSection(input: PolicyUpdateSectionInput!): PolicySectionMutationPayload! @beta
+  updatePolicy(input: WanNetworkPolicyUpdateInput!): WanNetworkPolicyMutationPayload!
+  updateRule(input: WanNetworkUpdateRuleInput!): WanNetworkRuleMutationPayload!
+  updateSection(input: PolicyUpdateSectionInput!): PolicySectionMutationPayload!
 }
 
 type WanNetworkPolicyQueries {
-  policy(input: WanNetworkPolicyInput): WanNetworkPolicy! @beta
-  revisions: PolicyRevisionsPayload @beta
+  policy(input: WanNetworkPolicyInput): WanNetworkPolicy!
+  revisions: PolicyRevisionsPayload
 }
 
 type WanNetworkPolicyRef implements ObjectRef & PolicyRef {
@@ -7770,23 +7927,23 @@ type ZtnaAlwaysOnPolicyMutationPayload implements IPolicyMutationPayload {
 }
 
 type ZtnaAlwaysOnPolicyMutations {
-  addRule(input: ZtnaAlwaysOnAddRuleInput!): ZtnaAlwaysOnRuleMutationPayload! @beta
-  addSection(input: PolicyAddSectionInput!): PolicySectionMutationPayload! @beta
-  createPolicyRevision(input: PolicyCreateRevisionInput!): ZtnaAlwaysOnPolicyMutationPayload! @beta
-  discardPolicyRevision(input: PolicyDiscardRevisionInput): ZtnaAlwaysOnPolicyMutationPayload! @beta
-  moveRule(input: PolicyMoveRuleInput!): ZtnaAlwaysOnRuleMutationPayload! @beta
-  moveSection(input: PolicyMoveSectionInput!): PolicySectionMutationPayload! @beta
-  publishPolicyRevision(input: PolicyPublishRevisionInput): ZtnaAlwaysOnPolicyMutationPayload! @beta
-  removeRule(input: ZtnaAlwaysOnRemoveRuleInput!): ZtnaAlwaysOnRuleMutationPayload! @beta
-  removeSection(input: PolicyRemoveSectionInput!): PolicySectionMutationPayload! @beta
-  updatePolicy(input: ZtnaAlwaysOnPolicyUpdateInput!): ZtnaAlwaysOnPolicyMutationPayload! @beta
-  updateRule(input: ZtnaAlwaysOnUpdateRuleInput!): ZtnaAlwaysOnRuleMutationPayload! @beta
-  updateSection(input: PolicyUpdateSectionInput!): PolicySectionMutationPayload! @beta
+  addRule(input: ZtnaAlwaysOnAddRuleInput!): ZtnaAlwaysOnRuleMutationPayload!
+  addSection(input: PolicyAddSectionInput!): PolicySectionMutationPayload!
+  createPolicyRevision(input: PolicyCreateRevisionInput!): ZtnaAlwaysOnPolicyMutationPayload!
+  discardPolicyRevision(input: PolicyDiscardRevisionInput): ZtnaAlwaysOnPolicyMutationPayload!
+  moveRule(input: PolicyMoveRuleInput!): ZtnaAlwaysOnRuleMutationPayload!
+  moveSection(input: PolicyMoveSectionInput!): PolicySectionMutationPayload!
+  publishPolicyRevision(input: PolicyPublishRevisionInput): ZtnaAlwaysOnPolicyMutationPayload!
+  removeRule(input: ZtnaAlwaysOnRemoveRuleInput!): ZtnaAlwaysOnRuleMutationPayload!
+  removeSection(input: PolicyRemoveSectionInput!): PolicySectionMutationPayload!
+  updatePolicy(input: ZtnaAlwaysOnPolicyUpdateInput!): ZtnaAlwaysOnPolicyMutationPayload!
+  updateRule(input: ZtnaAlwaysOnUpdateRuleInput!): ZtnaAlwaysOnRuleMutationPayload!
+  updateSection(input: PolicyUpdateSectionInput!): PolicySectionMutationPayload!
 }
 
 type ZtnaAlwaysOnPolicyQueries {
-  policy(input: ZtnaAlwaysOnPolicyInput): ZtnaAlwaysOnPolicy! @beta
-  revisions: PolicyRevisionsPayload @beta
+  policy(input: ZtnaAlwaysOnPolicyInput): ZtnaAlwaysOnPolicy!
+  revisions: PolicyRevisionsPayload
 }
 
 type ZtnaAlwaysOnRule implements IPolicyRule {
@@ -9974,6 +10131,10 @@ input EnableUserInput {
   userId: [Long!]!
 }
 
+input EncryptKeytabFileInput {
+  file: Upload!
+}
+
 input EngineTypePredicate {
   in: [StoryEngineTypeEnum!]
   not_in: [StoryEngineTypeEnum!]
@@ -11382,6 +11543,7 @@ input PopLocationUpdateAllocatedIpDescriptionInput {
 }
 
 input PopLocationUpdateBgpProfileInput {
+  communities: [BgpCommunityInput!]
   description: String
   id: ID!
   name: String
@@ -11880,6 +12042,148 @@ input SiteUpgradeRequest {
 
 input SiteUpgradeScheduleInput {
   time: DateTime!
+}
+
+input SiteWebProxyAddRuleDataInput {
+  associatedSite: [SiteRefInput!]! = []
+  authenticationConfig: SiteWebProxyAuthenticationConfigInput! = {kerberosConfig:{isEnabled:false}}
+  description: String! = ""
+  enabled: Boolean!
+  fqdn: Fqdn!
+  name: String!
+  port: Port!
+  shouldAssociateWithAllSites: Boolean! = false
+}
+
+input SiteWebProxyAddRuleInput {
+  at: PolicyRulePositionInput
+  rule: SiteWebProxyAddRuleDataInput!
+}
+
+""" Authentication configuration for the web proxy, including any required protocol-specific settings. """
+input SiteWebProxyAuthenticationConfigInput {
+  kerberosConfig: SiteWebProxyKerberosConfigInput = {isEnabled:false}
+  method: SiteWebProxyAuthMethod
+}
+
+""" Authentication configuration for the web proxy, including any required protocol-specific settings. """
+input SiteWebProxyAuthenticationConfigUpdateInput {
+  kerberosConfig: SiteWebProxyKerberosConfigUpdateInput
+  method: SiteWebProxyAuthMethod
+}
+
+""" Destination criteria matched by a web proxy traffic rule. To specify 'ANY' destination, an empty list must be provided for each match criteria field (e.g. fqdn: [], ip: []). """
+input SiteWebProxyDestinationInput {
+  domain: [Domain!]! = []
+  fqdn: [Fqdn!]! = []
+  ip: [IPAddress!]! = []
+}
+
+""" Destination criteria matched by a web proxy traffic rule. To specify 'ANY' destination, an empty list must be provided for each match criteria field (e.g. fqdn: [], ip: []). """
+input SiteWebProxyDestinationUpdateInput {
+  domain: [Domain!]
+  fqdn: [Fqdn!]
+  ip: [IPAddress!]
+}
+
+""" Kerberos authentication settings for the web proxy. """
+input SiteWebProxyKerberosConfigInput {
+  encryptedKeytab: String
+  isEnabled: Boolean! = false
+}
+
+""" Kerberos authentication settings for the web proxy. """
+input SiteWebProxyKerberosConfigUpdateInput {
+  encryptedKeytab: String
+  isEnabled: Boolean
+}
+
+input SiteWebProxyPolicyInput {
+  revision: PolicyRevisionInput
+}
+
+input SiteWebProxyPolicyMutationInput {
+  revision: PolicyMutationRevisionInput
+}
+
+input SiteWebProxyPolicyUpdateInput {
+  state: PolicyToggleState
+}
+
+input SiteWebProxyRemoveRuleInput {
+  id: ID!
+}
+
+""" Source criteria matched by a web proxy traffic rule. To specify 'ANY' source, an empty list must be provided for each match criteria field (e.g. ip: [], site: [], etc...). """
+input SiteWebProxySourceInput {
+  globalIpRange: [GlobalIpRangeRefInput!]! = []
+  group: [GroupRefInput!]! = []
+  ip: [IPAddress!]! = []
+  ipRange: [IpAddressRangeInput!]! = []
+  networkInterface: [NetworkInterfaceRefInput!]! = []
+  site: [SiteRefInput!]! = []
+  siteNetworkSubnet: [SiteNetworkSubnetRefInput!]! = []
+  subnet: [NetworkSubnet!]! = []
+}
+
+""" Source criteria matched by a web proxy traffic rule. To specify 'ANY' source, an empty list must be provided for each match criteria field (e.g. ip: [], site: [], etc...). """
+input SiteWebProxySourceUpdateInput {
+  globalIpRange: [GlobalIpRangeRefInput!]
+  group: [GroupRefInput!]
+  ip: [IPAddress!]
+  ipRange: [IpAddressRangeInput!]
+  networkInterface: [NetworkInterfaceRefInput!]
+  site: [SiteRefInput!]
+  siteNetworkSubnet: [SiteNetworkSubnetRefInput!]
+  subnet: [NetworkSubnet!]
+}
+
+input SiteWebProxyTrafficAddRuleDataInput {
+  action: SiteWebProxyAction! = ALLOW
+  description: String! = ""
+  destination: SiteWebProxyDestinationInput! = {fqdn:[],ip:[],domain:[]}
+  enabled: Boolean!
+  name: String!
+  source: SiteWebProxySourceInput! = {ip:[],site:[],subnet:[],ipRange:[],networkInterface:[],siteNetworkSubnet:[],globalIpRange:[],group:[]}
+}
+
+input SiteWebProxyTrafficAddRuleInput {
+  at: PolicySubRulePositionInput
+  rule: SiteWebProxyTrafficAddRuleDataInput!
+}
+
+input SiteWebProxyTrafficRemoveRuleInput {
+  id: ID!
+}
+
+input SiteWebProxyTrafficUpdateRuleDataInput {
+  action: SiteWebProxyAction
+  description: String
+  destination: SiteWebProxyDestinationUpdateInput
+  enabled: Boolean
+  name: String
+  source: SiteWebProxySourceUpdateInput
+}
+
+input SiteWebProxyTrafficUpdateRuleInput {
+  id: ID!
+  rule: SiteWebProxyTrafficUpdateRuleDataInput!
+}
+
+input SiteWebProxyUpdateRuleDataInput {
+  associatedSite: [SiteRefInput!]
+  authenticationConfig: SiteWebProxyAuthenticationConfigUpdateInput
+  description: String
+  enabled: Boolean
+  fqdn: Fqdn
+  name: String
+  port: Port
+  shouldAssociateWithAllSites: Boolean
+}
+
+input SiteWebProxyUpdateRuleInput {
+  id: ID!
+  rule: SiteWebProxyUpdateRuleDataInput!
 }
 
 input SiteWorkingHoursInput {
@@ -13093,6 +13397,11 @@ input UpdateHaInput {
   primaryManagementIp: IPAddress
   secondaryManagementIp: IPAddress
   vrid: Int
+  """
+  Enable Cloud Router mode for a GCP vSocket HA site, using the Socket LAN interface for BGP peering.
+  Only relevant for GCP HA sites; requires the account and Sockets to support the feature.
+  """
+  isCloudRouter: Boolean
 }
 
 input UpdateHwShippingInput {
@@ -15750,13 +16059,13 @@ enum EventFieldName {
   domain_name
   """ Duration in milliseconds between the start and end of a transaction or operation. For example, in DNS or HTTP events, this reflects the time between the request and the corresponding response. CMA Name: Duration Ms """
   duration_ms
-  """ Dynamic Control IDs applied in the event. CMA Name: Dynamic Control IDs """
+  """ Control IDs applied in the event. CMA Name: Control IDs """
   dynamic_control_ids
-  """ Dynamic control names applied in the event. CMA Name: Dynamic Control Names """
+  """ Control names applied in the event. CMA Name: Control Names """
   dynamic_control_names
-  """ The scope of the dynamic control Applied in the event. CMA Name: Dynamic Control Scope """
+  """ The scope of the control applied in the event. CMA Name: Dynamic Control Scope """
   dynamic_control_scope
-  """ Dynamic control threat categories applied in the event. CMA Name: Dynamic Control Threat Categories """
+  """ Control threat categories applied in the event. CMA Name: Dynamic Control Threat Categories """
   dynamic_control_threat_categories
   """ Egress PoP Name. CMA Name: Egress PoP Name """
   egress_pop_name
@@ -17352,6 +17661,24 @@ enum SiteType {
   CLOUD_DC
   DATACENTER
   HEADQUARTERS
+}
+
+""" Action that the web proxy applies to traffic matching the rule. """
+enum SiteWebProxyAction {
+  """ Specifies that the web proxy should not authenticate users and should forward traffic as is. """
+  ALLOW
+  """ Specifies that the web proxy should authenticate users using the chosen authentication method. """
+  AUTHENTICATE
+  """ Specifies that the web proxy should block the traffic. """
+  BLOCK
+}
+
+""" Authentication method used by the web proxy. """
+enum SiteWebProxyAuthMethod {
+  """ Kerberos (keytab-based) authentication. """
+  KERBEROS
+  """ No authentication - traffic is forwarded without authenticating users. """
+  NONE
 }
 
 enum SocketAddOnExpansionSlotNumber {

--- a/client.go
+++ b/client.go
@@ -226534,2313 +226534,2313 @@ func (t *ObjectUpdateGlobalIPRangeBulk) GetObject() *ObjectUpdateGlobalIpRangeBu
 }
 
 type PolicyAntiMalwareFileHashAddRule struct {
-	Policy *PolicyAntiMalwareFileHashAddRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyAntiMalwareFileHashAddRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyAntiMalwareFileHashAddRule) GetPolicy() *PolicyAntiMalwareFileHashAddRule_Policy {
 	if t == nil {
 		t = &PolicyAntiMalwareFileHashAddRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyAntiMalwareFileHashAddSection struct {
-	Policy *PolicyAntiMalwareFileHashAddSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyAntiMalwareFileHashAddSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyAntiMalwareFileHashAddSection) GetPolicy() *PolicyAntiMalwareFileHashAddSection_Policy {
 	if t == nil {
 		t = &PolicyAntiMalwareFileHashAddSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyAntiMalwareFileHashCreatePolicyRevision struct {
-	Policy *PolicyAntiMalwareFileHashCreatePolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyAntiMalwareFileHashCreatePolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyAntiMalwareFileHashCreatePolicyRevision) GetPolicy() *PolicyAntiMalwareFileHashCreatePolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyAntiMalwareFileHashCreatePolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyAntiMalwareFileHashDiscardPolicyRevision struct {
-	Policy *PolicyAntiMalwareFileHashDiscardPolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyAntiMalwareFileHashDiscardPolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyAntiMalwareFileHashDiscardPolicyRevision) GetPolicy() *PolicyAntiMalwareFileHashDiscardPolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyAntiMalwareFileHashDiscardPolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyAntiMalwareFileHashMoveRule struct {
-	Policy *PolicyAntiMalwareFileHashMoveRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyAntiMalwareFileHashMoveRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyAntiMalwareFileHashMoveRule) GetPolicy() *PolicyAntiMalwareFileHashMoveRule_Policy {
 	if t == nil {
 		t = &PolicyAntiMalwareFileHashMoveRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyAntiMalwareFileHashMoveSection struct {
-	Policy *PolicyAntiMalwareFileHashMoveSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyAntiMalwareFileHashMoveSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyAntiMalwareFileHashMoveSection) GetPolicy() *PolicyAntiMalwareFileHashMoveSection_Policy {
 	if t == nil {
 		t = &PolicyAntiMalwareFileHashMoveSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyAntiMalwareFileHashPublishPolicyRevision struct {
-	Policy *PolicyAntiMalwareFileHashPublishPolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyAntiMalwareFileHashPublishPolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyAntiMalwareFileHashPublishPolicyRevision) GetPolicy() *PolicyAntiMalwareFileHashPublishPolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyAntiMalwareFileHashPublishPolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyAntiMalwareFileHashRemoveRule struct {
-	Policy *PolicyAntiMalwareFileHashRemoveRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyAntiMalwareFileHashRemoveRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyAntiMalwareFileHashRemoveRule) GetPolicy() *PolicyAntiMalwareFileHashRemoveRule_Policy {
 	if t == nil {
 		t = &PolicyAntiMalwareFileHashRemoveRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyAntiMalwareFileHashRemoveSection struct {
-	Policy *PolicyAntiMalwareFileHashRemoveSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyAntiMalwareFileHashRemoveSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyAntiMalwareFileHashRemoveSection) GetPolicy() *PolicyAntiMalwareFileHashRemoveSection_Policy {
 	if t == nil {
 		t = &PolicyAntiMalwareFileHashRemoveSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyAntiMalwareFileHashUpdatePolicy struct {
-	Policy *PolicyAntiMalwareFileHashUpdatePolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyAntiMalwareFileHashUpdatePolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyAntiMalwareFileHashUpdatePolicy) GetPolicy() *PolicyAntiMalwareFileHashUpdatePolicy_Policy {
 	if t == nil {
 		t = &PolicyAntiMalwareFileHashUpdatePolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyAntiMalwareFileHashUpdateRule struct {
-	Policy *PolicyAntiMalwareFileHashUpdateRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyAntiMalwareFileHashUpdateRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyAntiMalwareFileHashUpdateRule) GetPolicy() *PolicyAntiMalwareFileHashUpdateRule_Policy {
 	if t == nil {
 		t = &PolicyAntiMalwareFileHashUpdateRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyAntiMalwareFileHashUpdateSection struct {
-	Policy *PolicyAntiMalwareFileHashUpdateSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyAntiMalwareFileHashUpdateSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyAntiMalwareFileHashUpdateSection) GetPolicy() *PolicyAntiMalwareFileHashUpdateSection_Policy {
 	if t == nil {
 		t = &PolicyAntiMalwareFileHashUpdateSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyAppTenantRestrictionAddRule struct {
-	Policy *PolicyAppTenantRestrictionAddRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyAppTenantRestrictionAddRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyAppTenantRestrictionAddRule) GetPolicy() *PolicyAppTenantRestrictionAddRule_Policy {
 	if t == nil {
 		t = &PolicyAppTenantRestrictionAddRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyAppTenantRestrictionAddSection struct {
-	Policy *PolicyAppTenantRestrictionAddSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyAppTenantRestrictionAddSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyAppTenantRestrictionAddSection) GetPolicy() *PolicyAppTenantRestrictionAddSection_Policy {
 	if t == nil {
 		t = &PolicyAppTenantRestrictionAddSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyAppTenantRestrictionCreatePolicyRevision struct {
-	Policy *PolicyAppTenantRestrictionCreatePolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyAppTenantRestrictionCreatePolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyAppTenantRestrictionCreatePolicyRevision) GetPolicy() *PolicyAppTenantRestrictionCreatePolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyAppTenantRestrictionCreatePolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyAppTenantRestrictionDiscardPolicyRevision struct {
-	Policy *PolicyAppTenantRestrictionDiscardPolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyAppTenantRestrictionDiscardPolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyAppTenantRestrictionDiscardPolicyRevision) GetPolicy() *PolicyAppTenantRestrictionDiscardPolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyAppTenantRestrictionDiscardPolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyAppTenantRestrictionMoveRule struct {
-	Policy *PolicyAppTenantRestrictionMoveRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyAppTenantRestrictionMoveRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyAppTenantRestrictionMoveRule) GetPolicy() *PolicyAppTenantRestrictionMoveRule_Policy {
 	if t == nil {
 		t = &PolicyAppTenantRestrictionMoveRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyAppTenantRestrictionMoveSection struct {
-	Policy *PolicyAppTenantRestrictionMoveSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyAppTenantRestrictionMoveSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyAppTenantRestrictionMoveSection) GetPolicy() *PolicyAppTenantRestrictionMoveSection_Policy {
 	if t == nil {
 		t = &PolicyAppTenantRestrictionMoveSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyAppTenantRestrictionPublishPolicyRevision struct {
-	Policy *PolicyAppTenantRestrictionPublishPolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyAppTenantRestrictionPublishPolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyAppTenantRestrictionPublishPolicyRevision) GetPolicy() *PolicyAppTenantRestrictionPublishPolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyAppTenantRestrictionPublishPolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyAppTenantRestrictionRemoveRule struct {
-	Policy *PolicyAppTenantRestrictionRemoveRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyAppTenantRestrictionRemoveRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyAppTenantRestrictionRemoveRule) GetPolicy() *PolicyAppTenantRestrictionRemoveRule_Policy {
 	if t == nil {
 		t = &PolicyAppTenantRestrictionRemoveRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyAppTenantRestrictionRemoveSection struct {
-	Policy *PolicyAppTenantRestrictionRemoveSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyAppTenantRestrictionRemoveSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyAppTenantRestrictionRemoveSection) GetPolicy() *PolicyAppTenantRestrictionRemoveSection_Policy {
 	if t == nil {
 		t = &PolicyAppTenantRestrictionRemoveSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyAppTenantRestrictionUpdatePolicy struct {
-	Policy *PolicyAppTenantRestrictionUpdatePolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyAppTenantRestrictionUpdatePolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyAppTenantRestrictionUpdatePolicy) GetPolicy() *PolicyAppTenantRestrictionUpdatePolicy_Policy {
 	if t == nil {
 		t = &PolicyAppTenantRestrictionUpdatePolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyAppTenantRestrictionUpdateRule struct {
-	Policy *PolicyAppTenantRestrictionUpdateRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyAppTenantRestrictionUpdateRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyAppTenantRestrictionUpdateRule) GetPolicy() *PolicyAppTenantRestrictionUpdateRule_Policy {
 	if t == nil {
 		t = &PolicyAppTenantRestrictionUpdateRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyAppTenantRestrictionUpdateSection struct {
-	Policy *PolicyAppTenantRestrictionUpdateSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyAppTenantRestrictionUpdateSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyAppTenantRestrictionUpdateSection) GetPolicy() *PolicyAppTenantRestrictionUpdateSection_Policy {
 	if t == nil {
 		t = &PolicyAppTenantRestrictionUpdateSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyApplicationControlAddRule struct {
-	Policy *PolicyApplicationControlAddRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyApplicationControlAddRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyApplicationControlAddRule) GetPolicy() *PolicyApplicationControlAddRule_Policy {
 	if t == nil {
 		t = &PolicyApplicationControlAddRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyApplicationControlAddSection struct {
-	Policy *PolicyApplicationControlAddSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyApplicationControlAddSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyApplicationControlAddSection) GetPolicy() *PolicyApplicationControlAddSection_Policy {
 	if t == nil {
 		t = &PolicyApplicationControlAddSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyApplicationControlCreatePolicyRevision struct {
-	Policy *PolicyApplicationControlCreatePolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyApplicationControlCreatePolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyApplicationControlCreatePolicyRevision) GetPolicy() *PolicyApplicationControlCreatePolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyApplicationControlCreatePolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyApplicationControlDiscardPolicyRevision struct {
-	Policy *PolicyApplicationControlDiscardPolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyApplicationControlDiscardPolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyApplicationControlDiscardPolicyRevision) GetPolicy() *PolicyApplicationControlDiscardPolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyApplicationControlDiscardPolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyApplicationControlMoveRule struct {
-	Policy *PolicyApplicationControlMoveRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyApplicationControlMoveRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyApplicationControlMoveRule) GetPolicy() *PolicyApplicationControlMoveRule_Policy {
 	if t == nil {
 		t = &PolicyApplicationControlMoveRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyApplicationControlMoveSection struct {
-	Policy *PolicyApplicationControlMoveSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyApplicationControlMoveSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyApplicationControlMoveSection) GetPolicy() *PolicyApplicationControlMoveSection_Policy {
 	if t == nil {
 		t = &PolicyApplicationControlMoveSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyApplicationControlPublishPolicyRevision struct {
-	Policy *PolicyApplicationControlPublishPolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyApplicationControlPublishPolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyApplicationControlPublishPolicyRevision) GetPolicy() *PolicyApplicationControlPublishPolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyApplicationControlPublishPolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyApplicationControlRemoveRule struct {
-	Policy *PolicyApplicationControlRemoveRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyApplicationControlRemoveRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyApplicationControlRemoveRule) GetPolicy() *PolicyApplicationControlRemoveRule_Policy {
 	if t == nil {
 		t = &PolicyApplicationControlRemoveRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyApplicationControlRemoveSection struct {
-	Policy *PolicyApplicationControlRemoveSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyApplicationControlRemoveSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyApplicationControlRemoveSection) GetPolicy() *PolicyApplicationControlRemoveSection_Policy {
 	if t == nil {
 		t = &PolicyApplicationControlRemoveSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyApplicationControlUpdatePolicy struct {
-	Policy *PolicyApplicationControlUpdatePolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyApplicationControlUpdatePolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyApplicationControlUpdatePolicy) GetPolicy() *PolicyApplicationControlUpdatePolicy_Policy {
 	if t == nil {
 		t = &PolicyApplicationControlUpdatePolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyApplicationControlUpdateRule struct {
-	Policy *PolicyApplicationControlUpdateRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyApplicationControlUpdateRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyApplicationControlUpdateRule) GetPolicy() *PolicyApplicationControlUpdateRule_Policy {
 	if t == nil {
 		t = &PolicyApplicationControlUpdateRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyApplicationControlUpdateSection struct {
-	Policy *PolicyApplicationControlUpdateSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyApplicationControlUpdateSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyApplicationControlUpdateSection) GetPolicy() *PolicyApplicationControlUpdateSection_Policy {
 	if t == nil {
 		t = &PolicyApplicationControlUpdateSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyClientConnectivityAddRule struct {
-	Policy *PolicyClientConnectivityAddRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyClientConnectivityAddRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyClientConnectivityAddRule) GetPolicy() *PolicyClientConnectivityAddRule_Policy {
 	if t == nil {
 		t = &PolicyClientConnectivityAddRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyClientConnectivityAddSection struct {
-	Policy *PolicyClientConnectivityAddSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyClientConnectivityAddSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyClientConnectivityAddSection) GetPolicy() *PolicyClientConnectivityAddSection_Policy {
 	if t == nil {
 		t = &PolicyClientConnectivityAddSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyClientConnectivityCreatePolicyRevision struct {
-	Policy *PolicyClientConnectivityCreatePolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyClientConnectivityCreatePolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyClientConnectivityCreatePolicyRevision) GetPolicy() *PolicyClientConnectivityCreatePolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyClientConnectivityCreatePolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyClientConnectivityDiscardPolicyRevision struct {
-	Policy *PolicyClientConnectivityDiscardPolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyClientConnectivityDiscardPolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyClientConnectivityDiscardPolicyRevision) GetPolicy() *PolicyClientConnectivityDiscardPolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyClientConnectivityDiscardPolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyClientConnectivityMoveRule struct {
-	Policy *PolicyClientConnectivityMoveRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyClientConnectivityMoveRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyClientConnectivityMoveRule) GetPolicy() *PolicyClientConnectivityMoveRule_Policy {
 	if t == nil {
 		t = &PolicyClientConnectivityMoveRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyClientConnectivityMoveSection struct {
-	Policy *PolicyClientConnectivityMoveSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyClientConnectivityMoveSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyClientConnectivityMoveSection) GetPolicy() *PolicyClientConnectivityMoveSection_Policy {
 	if t == nil {
 		t = &PolicyClientConnectivityMoveSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyClientConnectivityPublishPolicyRevision struct {
-	Policy *PolicyClientConnectivityPublishPolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyClientConnectivityPublishPolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyClientConnectivityPublishPolicyRevision) GetPolicy() *PolicyClientConnectivityPublishPolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyClientConnectivityPublishPolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyClientConnectivityRemoveRule struct {
-	Policy *PolicyClientConnectivityRemoveRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyClientConnectivityRemoveRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyClientConnectivityRemoveRule) GetPolicy() *PolicyClientConnectivityRemoveRule_Policy {
 	if t == nil {
 		t = &PolicyClientConnectivityRemoveRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyClientConnectivityRemoveSection struct {
-	Policy *PolicyClientConnectivityRemoveSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyClientConnectivityRemoveSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyClientConnectivityRemoveSection) GetPolicy() *PolicyClientConnectivityRemoveSection_Policy {
 	if t == nil {
 		t = &PolicyClientConnectivityRemoveSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyClientConnectivityUpdatePolicy struct {
-	Policy *PolicyClientConnectivityUpdatePolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyClientConnectivityUpdatePolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyClientConnectivityUpdatePolicy) GetPolicy() *PolicyClientConnectivityUpdatePolicy_Policy {
 	if t == nil {
 		t = &PolicyClientConnectivityUpdatePolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyClientConnectivityUpdateRule struct {
-	Policy *PolicyClientConnectivityUpdateRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyClientConnectivityUpdateRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyClientConnectivityUpdateRule) GetPolicy() *PolicyClientConnectivityUpdateRule_Policy {
 	if t == nil {
 		t = &PolicyClientConnectivityUpdateRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyClientConnectivityUpdateSection struct {
-	Policy *PolicyClientConnectivityUpdateSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyClientConnectivityUpdateSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyClientConnectivityUpdateSection) GetPolicy() *PolicyClientConnectivityUpdateSection_Policy {
 	if t == nil {
 		t = &PolicyClientConnectivityUpdateSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyInternetFirewallDiscardPolicyRevision struct {
-	Policy *PolicyInternetFirewallDiscardPolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyInternetFirewallDiscardPolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyInternetFirewallDiscardPolicyRevision) GetPolicy() *PolicyInternetFirewallDiscardPolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyInternetFirewallDiscardPolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyDynamicIPAllocationAddRule struct {
-	Policy *PolicyDynamicIpAllocationAddRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyDynamicIpAllocationAddRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyDynamicIPAllocationAddRule) GetPolicy() *PolicyDynamicIpAllocationAddRule_Policy {
 	if t == nil {
 		t = &PolicyDynamicIPAllocationAddRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyDynamicIPAllocationAddSection struct {
-	Policy *PolicyDynamicIpAllocationAddSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyDynamicIpAllocationAddSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyDynamicIPAllocationAddSection) GetPolicy() *PolicyDynamicIpAllocationAddSection_Policy {
 	if t == nil {
 		t = &PolicyDynamicIPAllocationAddSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyDynamicIPAllocationCreatePolicyRevision struct {
-	Policy *PolicyDynamicIpAllocationCreatePolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyDynamicIpAllocationCreatePolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyDynamicIPAllocationCreatePolicyRevision) GetPolicy() *PolicyDynamicIpAllocationCreatePolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyDynamicIPAllocationCreatePolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyDynamicIPAllocationDiscardPolicyRevision struct {
-	Policy *PolicyDynamicIpAllocationDiscardPolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyDynamicIpAllocationDiscardPolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyDynamicIPAllocationDiscardPolicyRevision) GetPolicy() *PolicyDynamicIpAllocationDiscardPolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyDynamicIPAllocationDiscardPolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyDynamicIPAllocationMoveRule struct {
-	Policy *PolicyDynamicIpAllocationMoveRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyDynamicIpAllocationMoveRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyDynamicIPAllocationMoveRule) GetPolicy() *PolicyDynamicIpAllocationMoveRule_Policy {
 	if t == nil {
 		t = &PolicyDynamicIPAllocationMoveRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyDynamicIPAllocationMoveSection struct {
-	Policy *PolicyDynamicIpAllocationMoveSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyDynamicIpAllocationMoveSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyDynamicIPAllocationMoveSection) GetPolicy() *PolicyDynamicIpAllocationMoveSection_Policy {
 	if t == nil {
 		t = &PolicyDynamicIPAllocationMoveSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyDynamicIPAllocationPublishPolicyRevision struct {
-	Policy *PolicyDynamicIpAllocationPublishPolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyDynamicIpAllocationPublishPolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyDynamicIPAllocationPublishPolicyRevision) GetPolicy() *PolicyDynamicIpAllocationPublishPolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyDynamicIPAllocationPublishPolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyDynamicIPAllocationRemoveRule struct {
-	Policy *PolicyDynamicIpAllocationRemoveRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyDynamicIpAllocationRemoveRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyDynamicIPAllocationRemoveRule) GetPolicy() *PolicyDynamicIpAllocationRemoveRule_Policy {
 	if t == nil {
 		t = &PolicyDynamicIPAllocationRemoveRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyDynamicIPAllocationRemoveSection struct {
-	Policy *PolicyDynamicIpAllocationRemoveSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyDynamicIpAllocationRemoveSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyDynamicIPAllocationRemoveSection) GetPolicy() *PolicyDynamicIpAllocationRemoveSection_Policy {
 	if t == nil {
 		t = &PolicyDynamicIPAllocationRemoveSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyDynamicIPAllocationUpdatePolicy struct {
-	Policy *PolicyDynamicIpAllocationUpdatePolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyDynamicIpAllocationUpdatePolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyDynamicIPAllocationUpdatePolicy) GetPolicy() *PolicyDynamicIpAllocationUpdatePolicy_Policy {
 	if t == nil {
 		t = &PolicyDynamicIPAllocationUpdatePolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyDynamicIPAllocationUpdateRule struct {
-	Policy *PolicyDynamicIpAllocationUpdateRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyDynamicIpAllocationUpdateRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyDynamicIPAllocationUpdateRule) GetPolicy() *PolicyDynamicIpAllocationUpdateRule_Policy {
 	if t == nil {
 		t = &PolicyDynamicIPAllocationUpdateRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyDynamicIPAllocationUpdateSection struct {
-	Policy *PolicyDynamicIpAllocationUpdateSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyDynamicIpAllocationUpdateSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyDynamicIPAllocationUpdateSection) GetPolicy() *PolicyDynamicIpAllocationUpdateSection_Policy {
 	if t == nil {
 		t = &PolicyDynamicIPAllocationUpdateSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyInternetFirewallAddRule struct {
-	Policy *PolicyInternetFirewallAddRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyInternetFirewallAddRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyInternetFirewallAddRule) GetPolicy() *PolicyInternetFirewallAddRule_Policy {
 	if t == nil {
 		t = &PolicyInternetFirewallAddRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyInternetFirewallAddSection struct {
-	Policy *PolicyInternetFirewallAddSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyInternetFirewallAddSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyInternetFirewallAddSection) GetPolicy() *PolicyInternetFirewallAddSection_Policy {
 	if t == nil {
 		t = &PolicyInternetFirewallAddSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyInternetFirewallAddSubPolicy struct {
-	Policy *PolicyInternetFirewallAddSubPolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyInternetFirewallAddSubPolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyInternetFirewallAddSubPolicy) GetPolicy() *PolicyInternetFirewallAddSubPolicy_Policy {
 	if t == nil {
 		t = &PolicyInternetFirewallAddSubPolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyInternetFirewallCreatePolicyRevision struct {
-	Policy *PolicyInternetFirewallCreatePolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyInternetFirewallCreatePolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyInternetFirewallCreatePolicyRevision) GetPolicy() *PolicyInternetFirewallCreatePolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyInternetFirewallCreatePolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyInternetFirewallMoveRule struct {
-	Policy *PolicyInternetFirewallMoveRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyInternetFirewallMoveRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyInternetFirewallMoveRule) GetPolicy() *PolicyInternetFirewallMoveRule_Policy {
 	if t == nil {
 		t = &PolicyInternetFirewallMoveRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyInternetFirewallMoveSection struct {
-	Policy *PolicyInternetFirewallMoveSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyInternetFirewallMoveSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyInternetFirewallMoveSection) GetPolicy() *PolicyInternetFirewallMoveSection_Policy {
 	if t == nil {
 		t = &PolicyInternetFirewallMoveSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyInternetFirewallPublishPolicyRevision struct {
-	Policy *PolicyInternetFirewallPublishPolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyInternetFirewallPublishPolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyInternetFirewallPublishPolicyRevision) GetPolicy() *PolicyInternetFirewallPublishPolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyInternetFirewallPublishPolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyInternetFirewallRemoveRule struct {
-	Policy *PolicyInternetFirewallRemoveRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyInternetFirewallRemoveRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyInternetFirewallRemoveRule) GetPolicy() *PolicyInternetFirewallRemoveRule_Policy {
 	if t == nil {
 		t = &PolicyInternetFirewallRemoveRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyInternetFirewallRemoveSection struct {
-	Policy *PolicyInternetFirewallRemoveSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyInternetFirewallRemoveSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyInternetFirewallRemoveSection) GetPolicy() *PolicyInternetFirewallRemoveSection_Policy {
 	if t == nil {
 		t = &PolicyInternetFirewallRemoveSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyInternetFirewallRemoveSubPolicy struct {
-	Policy *PolicyInternetFirewallRemoveSubPolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyInternetFirewallRemoveSubPolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyInternetFirewallRemoveSubPolicy) GetPolicy() *PolicyInternetFirewallRemoveSubPolicy_Policy {
 	if t == nil {
 		t = &PolicyInternetFirewallRemoveSubPolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyInternetFirewallReorderPolicy struct {
-	Policy *PolicyInternetFirewallReorderPolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyInternetFirewallReorderPolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyInternetFirewallReorderPolicy) GetPolicy() *PolicyInternetFirewallReorderPolicy_Policy {
 	if t == nil {
 		t = &PolicyInternetFirewallReorderPolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyInternetFirewallUpdatePolicy struct {
-	Policy *PolicyInternetFirewallUpdatePolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyInternetFirewallUpdatePolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyInternetFirewallUpdatePolicy) GetPolicy() *PolicyInternetFirewallUpdatePolicy_Policy {
 	if t == nil {
 		t = &PolicyInternetFirewallUpdatePolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyInternetFirewallUpdateRule struct {
-	Policy *PolicyInternetFirewallUpdateRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyInternetFirewallUpdateRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyInternetFirewallUpdateRule) GetPolicy() *PolicyInternetFirewallUpdateRule_Policy {
 	if t == nil {
 		t = &PolicyInternetFirewallUpdateRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyInternetFirewallUpdateSection struct {
-	Policy *PolicyInternetFirewallUpdateSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyInternetFirewallUpdateSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyInternetFirewallUpdateSection) GetPolicy() *PolicyInternetFirewallUpdateSection_Policy {
 	if t == nil {
 		t = &PolicyInternetFirewallUpdateSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyPrivateAccessAddRule struct {
-	Policy *PolicyPrivateAccessAddRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyPrivateAccessAddRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyPrivateAccessAddRule) GetPolicy() *PolicyPrivateAccessAddRule_Policy {
 	if t == nil {
 		t = &PolicyPrivateAccessAddRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyPrivateAccessAddSection struct {
-	Policy *PolicyPrivateAccessAddSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyPrivateAccessAddSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyPrivateAccessAddSection) GetPolicy() *PolicyPrivateAccessAddSection_Policy {
 	if t == nil {
 		t = &PolicyPrivateAccessAddSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyPrivateAccessCreatePolicyRevision struct {
-	Policy *PolicyPrivateAccessCreatePolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyPrivateAccessCreatePolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyPrivateAccessCreatePolicyRevision) GetPolicy() *PolicyPrivateAccessCreatePolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyPrivateAccessCreatePolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyPrivateAccessDeleteRule struct {
-	Policy *PolicyPrivateAccessDeleteRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyPrivateAccessDeleteRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyPrivateAccessDeleteRule) GetPolicy() *PolicyPrivateAccessDeleteRule_Policy {
 	if t == nil {
 		t = &PolicyPrivateAccessDeleteRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyPrivateAccessDiscardPolicyRevision struct {
-	Policy *PolicyPrivateAccessDiscardPolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyPrivateAccessDiscardPolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyPrivateAccessDiscardPolicyRevision) GetPolicy() *PolicyPrivateAccessDiscardPolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyPrivateAccessDiscardPolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyPrivateAccessDiscardRevision struct {
-	Policy *PolicyPrivateAccessDiscardRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyPrivateAccessDiscardRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyPrivateAccessDiscardRevision) GetPolicy() *PolicyPrivateAccessDiscardRevision_Policy {
 	if t == nil {
 		t = &PolicyPrivateAccessDiscardRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyPrivateAccessMoveRule struct {
-	Policy *PolicyPrivateAccessMoveRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyPrivateAccessMoveRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyPrivateAccessMoveRule) GetPolicy() *PolicyPrivateAccessMoveRule_Policy {
 	if t == nil {
 		t = &PolicyPrivateAccessMoveRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyPrivateAccessMoveSection struct {
-	Policy *PolicyPrivateAccessMoveSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyPrivateAccessMoveSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyPrivateAccessMoveSection) GetPolicy() *PolicyPrivateAccessMoveSection_Policy {
 	if t == nil {
 		t = &PolicyPrivateAccessMoveSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyPrivateAccessPublishPolicyRevision struct {
-	Policy *PolicyPrivateAccessPublishPolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyPrivateAccessPublishPolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyPrivateAccessPublishPolicyRevision) GetPolicy() *PolicyPrivateAccessPublishPolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyPrivateAccessPublishPolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyPrivateAccessPublishRevision struct {
-	Policy *PolicyPrivateAccessPublishRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyPrivateAccessPublishRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyPrivateAccessPublishRevision) GetPolicy() *PolicyPrivateAccessPublishRevision_Policy {
 	if t == nil {
 		t = &PolicyPrivateAccessPublishRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyPrivateAccessRemoveRule struct {
-	Policy *PolicyPrivateAccessRemoveRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyPrivateAccessRemoveRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyPrivateAccessRemoveRule) GetPolicy() *PolicyPrivateAccessRemoveRule_Policy {
 	if t == nil {
 		t = &PolicyPrivateAccessRemoveRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyPrivateAccessRemoveSection struct {
-	Policy *PolicyPrivateAccessRemoveSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyPrivateAccessRemoveSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyPrivateAccessRemoveSection) GetPolicy() *PolicyPrivateAccessRemoveSection_Policy {
 	if t == nil {
 		t = &PolicyPrivateAccessRemoveSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyPrivateAccessUpdatePolicy struct {
-	Policy *PolicyPrivateAccessUpdatePolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyPrivateAccessUpdatePolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyPrivateAccessUpdatePolicy) GetPolicy() *PolicyPrivateAccessUpdatePolicy_Policy {
 	if t == nil {
 		t = &PolicyPrivateAccessUpdatePolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyPrivateAccessUpdateRule struct {
-	Policy *PolicyPrivateAccessUpdateRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyPrivateAccessUpdateRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyPrivateAccessUpdateRule) GetPolicy() *PolicyPrivateAccessUpdateRule_Policy {
 	if t == nil {
 		t = &PolicyPrivateAccessUpdateRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyPrivateAccessUpdateSection struct {
-	Policy *PolicyPrivateAccessUpdateSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyPrivateAccessUpdateSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyPrivateAccessUpdateSection) GetPolicy() *PolicyPrivateAccessUpdateSection_Policy {
 	if t == nil {
 		t = &PolicyPrivateAccessUpdateSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyRemotePortFwdAddRule struct {
-	Policy *PolicyRemotePortFwdAddRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyRemotePortFwdAddRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyRemotePortFwdAddRule) GetPolicy() *PolicyRemotePortFwdAddRule_Policy {
 	if t == nil {
 		t = &PolicyRemotePortFwdAddRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyRemotePortFwdAddSection struct {
-	Policy *PolicyRemotePortFwdAddSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyRemotePortFwdAddSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyRemotePortFwdAddSection) GetPolicy() *PolicyRemotePortFwdAddSection_Policy {
 	if t == nil {
 		t = &PolicyRemotePortFwdAddSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyRemotePortFwdCreatePolicyRevision struct {
-	Policy *PolicyRemotePortFwdCreatePolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyRemotePortFwdCreatePolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyRemotePortFwdCreatePolicyRevision) GetPolicy() *PolicyRemotePortFwdCreatePolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyRemotePortFwdCreatePolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyRemotePortFwdDiscardPolicyRevision struct {
-	Policy *PolicyRemotePortFwdDiscardPolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyRemotePortFwdDiscardPolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyRemotePortFwdDiscardPolicyRevision) GetPolicy() *PolicyRemotePortFwdDiscardPolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyRemotePortFwdDiscardPolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyRemotePortFwdMoveRule struct {
-	Policy *PolicyRemotePortFwdMoveRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyRemotePortFwdMoveRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyRemotePortFwdMoveRule) GetPolicy() *PolicyRemotePortFwdMoveRule_Policy {
 	if t == nil {
 		t = &PolicyRemotePortFwdMoveRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyRemotePortFwdMoveSection struct {
-	Policy *PolicyRemotePortFwdMoveSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyRemotePortFwdMoveSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyRemotePortFwdMoveSection) GetPolicy() *PolicyRemotePortFwdMoveSection_Policy {
 	if t == nil {
 		t = &PolicyRemotePortFwdMoveSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyRemotePortFwdPublishPolicyRevision struct {
-	Policy *PolicyRemotePortFwdPublishPolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyRemotePortFwdPublishPolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyRemotePortFwdPublishPolicyRevision) GetPolicy() *PolicyRemotePortFwdPublishPolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyRemotePortFwdPublishPolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyRemotePortFwdRemoveRule struct {
-	Policy *PolicyRemotePortFwdRemoveRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyRemotePortFwdRemoveRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyRemotePortFwdRemoveRule) GetPolicy() *PolicyRemotePortFwdRemoveRule_Policy {
 	if t == nil {
 		t = &PolicyRemotePortFwdRemoveRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyRemotePortFwdRemoveSection struct {
-	Policy *PolicyRemotePortFwdRemoveSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyRemotePortFwdRemoveSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyRemotePortFwdRemoveSection) GetPolicy() *PolicyRemotePortFwdRemoveSection_Policy {
 	if t == nil {
 		t = &PolicyRemotePortFwdRemoveSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyRemotePortFwdUpdatePolicy struct {
-	Policy *PolicyRemotePortFwdUpdatePolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyRemotePortFwdUpdatePolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyRemotePortFwdUpdatePolicy) GetPolicy() *PolicyRemotePortFwdUpdatePolicy_Policy {
 	if t == nil {
 		t = &PolicyRemotePortFwdUpdatePolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyRemotePortFwdUpdateRule struct {
-	Policy *PolicyRemotePortFwdUpdateRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyRemotePortFwdUpdateRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyRemotePortFwdUpdateRule) GetPolicy() *PolicyRemotePortFwdUpdateRule_Policy {
 	if t == nil {
 		t = &PolicyRemotePortFwdUpdateRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyRemotePortFwdUpdateSection struct {
-	Policy *PolicyRemotePortFwdUpdateSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyRemotePortFwdUpdateSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyRemotePortFwdUpdateSection) GetPolicy() *PolicyRemotePortFwdUpdateSection_Policy {
 	if t == nil {
 		t = &PolicyRemotePortFwdUpdateSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySocketBypassAddRule struct {
-	Policy *PolicySocketBypassAddRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySocketBypassAddRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySocketBypassAddRule) GetPolicy() *PolicySocketBypassAddRule_Policy {
 	if t == nil {
 		t = &PolicySocketBypassAddRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySocketBypassAddSection struct {
-	Policy *PolicySocketBypassAddSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySocketBypassAddSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySocketBypassAddSection) GetPolicy() *PolicySocketBypassAddSection_Policy {
 	if t == nil {
 		t = &PolicySocketBypassAddSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySocketBypassCreatePolicyRevision struct {
-	Policy *PolicySocketBypassCreatePolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySocketBypassCreatePolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySocketBypassCreatePolicyRevision) GetPolicy() *PolicySocketBypassCreatePolicyRevision_Policy {
 	if t == nil {
 		t = &PolicySocketBypassCreatePolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySocketBypassDiscardPolicyRevision struct {
-	Policy *PolicySocketBypassDiscardPolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySocketBypassDiscardPolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySocketBypassDiscardPolicyRevision) GetPolicy() *PolicySocketBypassDiscardPolicyRevision_Policy {
 	if t == nil {
 		t = &PolicySocketBypassDiscardPolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySocketBypassMoveRule struct {
-	Policy *PolicySocketBypassMoveRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySocketBypassMoveRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySocketBypassMoveRule) GetPolicy() *PolicySocketBypassMoveRule_Policy {
 	if t == nil {
 		t = &PolicySocketBypassMoveRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySocketBypassMoveSection struct {
-	Policy *PolicySocketBypassMoveSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySocketBypassMoveSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySocketBypassMoveSection) GetPolicy() *PolicySocketBypassMoveSection_Policy {
 	if t == nil {
 		t = &PolicySocketBypassMoveSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySocketBypassPublishPolicyRevision struct {
-	Policy *PolicySocketBypassPublishPolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySocketBypassPublishPolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySocketBypassPublishPolicyRevision) GetPolicy() *PolicySocketBypassPublishPolicyRevision_Policy {
 	if t == nil {
 		t = &PolicySocketBypassPublishPolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySocketBypassRemoveRule struct {
-	Policy *PolicySocketBypassRemoveRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySocketBypassRemoveRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySocketBypassRemoveRule) GetPolicy() *PolicySocketBypassRemoveRule_Policy {
 	if t == nil {
 		t = &PolicySocketBypassRemoveRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySocketBypassRemoveSection struct {
-	Policy *PolicySocketBypassRemoveSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySocketBypassRemoveSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySocketBypassRemoveSection) GetPolicy() *PolicySocketBypassRemoveSection_Policy {
 	if t == nil {
 		t = &PolicySocketBypassRemoveSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySocketBypassReorderPolicy struct {
-	Policy *PolicySocketBypassReorderPolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySocketBypassReorderPolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySocketBypassReorderPolicy) GetPolicy() *PolicySocketBypassReorderPolicy_Policy {
 	if t == nil {
 		t = &PolicySocketBypassReorderPolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySocketBypassUpdatePolicy struct {
-	Policy *PolicySocketBypassUpdatePolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySocketBypassUpdatePolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySocketBypassUpdatePolicy) GetPolicy() *PolicySocketBypassUpdatePolicy_Policy {
 	if t == nil {
 		t = &PolicySocketBypassUpdatePolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySocketBypassUpdateRule struct {
-	Policy *PolicySocketBypassUpdateRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySocketBypassUpdateRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySocketBypassUpdateRule) GetPolicy() *PolicySocketBypassUpdateRule_Policy {
 	if t == nil {
 		t = &PolicySocketBypassUpdateRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySocketBypassUpdateSection struct {
-	Policy *PolicySocketBypassUpdateSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySocketBypassUpdateSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySocketBypassUpdateSection) GetPolicy() *PolicySocketBypassUpdateSection_Policy {
 	if t == nil {
 		t = &PolicySocketBypassUpdateSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySocketLanAddRule struct {
-	Policy *PolicySocketLanAddRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySocketLanAddRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySocketLanAddRule) GetPolicy() *PolicySocketLanAddRule_Policy {
 	if t == nil {
 		t = &PolicySocketLanAddRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySocketLanAddSection struct {
-	Policy *PolicySocketLanAddSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySocketLanAddSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySocketLanAddSection) GetPolicy() *PolicySocketLanAddSection_Policy {
 	if t == nil {
 		t = &PolicySocketLanAddSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySocketLanAddSubPolicy struct {
-	Policy *PolicySocketLanAddSubPolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySocketLanAddSubPolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySocketLanAddSubPolicy) GetPolicy() *PolicySocketLanAddSubPolicy_Policy {
 	if t == nil {
 		t = &PolicySocketLanAddSubPolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySocketLanCreatePolicyRevision struct {
-	Policy *PolicySocketLanCreatePolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySocketLanCreatePolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySocketLanCreatePolicyRevision) GetPolicy() *PolicySocketLanCreatePolicyRevision_Policy {
 	if t == nil {
 		t = &PolicySocketLanCreatePolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySocketLanDiscardPolicyRevision struct {
-	Policy *PolicySocketLanDiscardPolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySocketLanDiscardPolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySocketLanDiscardPolicyRevision) GetPolicy() *PolicySocketLanDiscardPolicyRevision_Policy {
 	if t == nil {
 		t = &PolicySocketLanDiscardPolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySocketLanFirewallAddRule struct {
-	Policy *PolicySocketLanFirewallAddRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySocketLanFirewallAddRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySocketLanFirewallAddRule) GetPolicy() *PolicySocketLanFirewallAddRule_Policy {
 	if t == nil {
 		t = &PolicySocketLanFirewallAddRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySocketLanFirewallMoveRule struct {
-	Policy *PolicySocketLanFirewallMoveRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySocketLanFirewallMoveRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySocketLanFirewallMoveRule) GetPolicy() *PolicySocketLanFirewallMoveRule_Policy {
 	if t == nil {
 		t = &PolicySocketLanFirewallMoveRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySocketLanFirewallRemoveRule struct {
-	Policy *PolicySocketLanFirewallRemoveRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySocketLanFirewallRemoveRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySocketLanFirewallRemoveRule) GetPolicy() *PolicySocketLanFirewallRemoveRule_Policy {
 	if t == nil {
 		t = &PolicySocketLanFirewallRemoveRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySocketLanFirewallUpdateRule struct {
-	Policy *PolicySocketLanFirewallUpdateRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySocketLanFirewallUpdateRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySocketLanFirewallUpdateRule) GetPolicy() *PolicySocketLanFirewallUpdateRule_Policy {
 	if t == nil {
 		t = &PolicySocketLanFirewallUpdateRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySocketLanMoveRule struct {
-	Policy *PolicySocketLanMoveRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySocketLanMoveRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySocketLanMoveRule) GetPolicy() *PolicySocketLanMoveRule_Policy {
 	if t == nil {
 		t = &PolicySocketLanMoveRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySocketLanMoveSection struct {
-	Policy *PolicySocketLanMoveSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySocketLanMoveSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySocketLanMoveSection) GetPolicy() *PolicySocketLanMoveSection_Policy {
 	if t == nil {
 		t = &PolicySocketLanMoveSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySocketLanPublishPolicyRevision struct {
-	Policy *PolicySocketLanPublishPolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySocketLanPublishPolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySocketLanPublishPolicyRevision) GetPolicy() *PolicySocketLanPublishPolicyRevision_Policy {
 	if t == nil {
 		t = &PolicySocketLanPublishPolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySocketLanRemoveRule struct {
-	Policy *PolicySocketLanRemoveRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySocketLanRemoveRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySocketLanRemoveRule) GetPolicy() *PolicySocketLanRemoveRule_Policy {
 	if t == nil {
 		t = &PolicySocketLanRemoveRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySocketLanRemoveSection struct {
-	Policy *PolicySocketLanRemoveSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySocketLanRemoveSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySocketLanRemoveSection) GetPolicy() *PolicySocketLanRemoveSection_Policy {
 	if t == nil {
 		t = &PolicySocketLanRemoveSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySocketLanRemoveSubPolicy struct {
-	Policy *PolicySocketLanRemoveSubPolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySocketLanRemoveSubPolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySocketLanRemoveSubPolicy) GetPolicy() *PolicySocketLanRemoveSubPolicy_Policy {
 	if t == nil {
 		t = &PolicySocketLanRemoveSubPolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySocketLanReorderPolicy struct {
-	Policy *PolicySocketLanReorderPolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySocketLanReorderPolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySocketLanReorderPolicy) GetPolicy() *PolicySocketLanReorderPolicy_Policy {
 	if t == nil {
 		t = &PolicySocketLanReorderPolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySocketLanUpdatePolicy struct {
-	Policy *PolicySocketLanUpdatePolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySocketLanUpdatePolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySocketLanUpdatePolicy) GetPolicy() *PolicySocketLanUpdatePolicy_Policy {
 	if t == nil {
 		t = &PolicySocketLanUpdatePolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySocketLanUpdateRule struct {
-	Policy *PolicySocketLanUpdateRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySocketLanUpdateRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySocketLanUpdateRule) GetPolicy() *PolicySocketLanUpdateRule_Policy {
 	if t == nil {
 		t = &PolicySocketLanUpdateRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySocketLanUpdateSection struct {
-	Policy *PolicySocketLanUpdateSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySocketLanUpdateSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySocketLanUpdateSection) GetPolicy() *PolicySocketLanUpdateSection_Policy {
 	if t == nil {
 		t = &PolicySocketLanUpdateSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySplitTunnelAddRule struct {
-	Policy *PolicySplitTunnelAddRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySplitTunnelAddRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySplitTunnelAddRule) GetPolicy() *PolicySplitTunnelAddRule_Policy {
 	if t == nil {
 		t = &PolicySplitTunnelAddRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySplitTunnelAddSection struct {
-	Policy *PolicySplitTunnelAddSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySplitTunnelAddSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySplitTunnelAddSection) GetPolicy() *PolicySplitTunnelAddSection_Policy {
 	if t == nil {
 		t = &PolicySplitTunnelAddSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySplitTunnelCreatePolicyRevision struct {
-	Policy *PolicySplitTunnelCreatePolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySplitTunnelCreatePolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySplitTunnelCreatePolicyRevision) GetPolicy() *PolicySplitTunnelCreatePolicyRevision_Policy {
 	if t == nil {
 		t = &PolicySplitTunnelCreatePolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySplitTunnelDiscardPolicyRevision struct {
-	Policy *PolicySplitTunnelDiscardPolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySplitTunnelDiscardPolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySplitTunnelDiscardPolicyRevision) GetPolicy() *PolicySplitTunnelDiscardPolicyRevision_Policy {
 	if t == nil {
 		t = &PolicySplitTunnelDiscardPolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySplitTunnelMoveRule struct {
-	Policy *PolicySplitTunnelMoveRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySplitTunnelMoveRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySplitTunnelMoveRule) GetPolicy() *PolicySplitTunnelMoveRule_Policy {
 	if t == nil {
 		t = &PolicySplitTunnelMoveRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySplitTunnelMoveSection struct {
-	Policy *PolicySplitTunnelMoveSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySplitTunnelMoveSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySplitTunnelMoveSection) GetPolicy() *PolicySplitTunnelMoveSection_Policy {
 	if t == nil {
 		t = &PolicySplitTunnelMoveSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySplitTunnelPublishPolicyRevision struct {
-	Policy *PolicySplitTunnelPublishPolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySplitTunnelPublishPolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySplitTunnelPublishPolicyRevision) GetPolicy() *PolicySplitTunnelPublishPolicyRevision_Policy {
 	if t == nil {
 		t = &PolicySplitTunnelPublishPolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySplitTunnelRemoveRule struct {
-	Policy *PolicySplitTunnelRemoveRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySplitTunnelRemoveRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySplitTunnelRemoveRule) GetPolicy() *PolicySplitTunnelRemoveRule_Policy {
 	if t == nil {
 		t = &PolicySplitTunnelRemoveRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySplitTunnelRemoveSection struct {
-	Policy *PolicySplitTunnelRemoveSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySplitTunnelRemoveSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySplitTunnelRemoveSection) GetPolicy() *PolicySplitTunnelRemoveSection_Policy {
 	if t == nil {
 		t = &PolicySplitTunnelRemoveSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySplitTunnelUpdatePolicy struct {
-	Policy *PolicySplitTunnelUpdatePolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySplitTunnelUpdatePolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySplitTunnelUpdatePolicy) GetPolicy() *PolicySplitTunnelUpdatePolicy_Policy {
 	if t == nil {
 		t = &PolicySplitTunnelUpdatePolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySplitTunnelUpdateRule struct {
-	Policy *PolicySplitTunnelUpdateRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySplitTunnelUpdateRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySplitTunnelUpdateRule) GetPolicy() *PolicySplitTunnelUpdateRule_Policy {
 	if t == nil {
 		t = &PolicySplitTunnelUpdateRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySplitTunnelUpdateSection struct {
-	Policy *PolicySplitTunnelUpdateSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySplitTunnelUpdateSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySplitTunnelUpdateSection) GetPolicy() *PolicySplitTunnelUpdateSection_Policy {
 	if t == nil {
 		t = &PolicySplitTunnelUpdateSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyTerminalServerAddRule struct {
-	Policy *PolicyTerminalServerAddRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyTerminalServerAddRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyTerminalServerAddRule) GetPolicy() *PolicyTerminalServerAddRule_Policy {
 	if t == nil {
 		t = &PolicyTerminalServerAddRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyTerminalServerAddSection struct {
-	Policy *PolicyTerminalServerAddSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyTerminalServerAddSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyTerminalServerAddSection) GetPolicy() *PolicyTerminalServerAddSection_Policy {
 	if t == nil {
 		t = &PolicyTerminalServerAddSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyTerminalServerCreatePolicyRevision struct {
-	Policy *PolicyTerminalServerCreatePolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyTerminalServerCreatePolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyTerminalServerCreatePolicyRevision) GetPolicy() *PolicyTerminalServerCreatePolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyTerminalServerCreatePolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyTerminalServerDiscardPolicyRevision struct {
-	Policy *PolicyTerminalServerDiscardPolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyTerminalServerDiscardPolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyTerminalServerDiscardPolicyRevision) GetPolicy() *PolicyTerminalServerDiscardPolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyTerminalServerDiscardPolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyTerminalServerMoveRule struct {
-	Policy *PolicyTerminalServerMoveRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyTerminalServerMoveRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyTerminalServerMoveRule) GetPolicy() *PolicyTerminalServerMoveRule_Policy {
 	if t == nil {
 		t = &PolicyTerminalServerMoveRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyTerminalServerMoveSection struct {
-	Policy *PolicyTerminalServerMoveSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyTerminalServerMoveSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyTerminalServerMoveSection) GetPolicy() *PolicyTerminalServerMoveSection_Policy {
 	if t == nil {
 		t = &PolicyTerminalServerMoveSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyTerminalServerPublishPolicyRevision struct {
-	Policy *PolicyTerminalServerPublishPolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyTerminalServerPublishPolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyTerminalServerPublishPolicyRevision) GetPolicy() *PolicyTerminalServerPublishPolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyTerminalServerPublishPolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyTerminalServerRemoveRule struct {
-	Policy *PolicyTerminalServerRemoveRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyTerminalServerRemoveRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyTerminalServerRemoveRule) GetPolicy() *PolicyTerminalServerRemoveRule_Policy {
 	if t == nil {
 		t = &PolicyTerminalServerRemoveRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyTerminalServerRemoveSection struct {
-	Policy *PolicyTerminalServerRemoveSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyTerminalServerRemoveSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyTerminalServerRemoveSection) GetPolicy() *PolicyTerminalServerRemoveSection_Policy {
 	if t == nil {
 		t = &PolicyTerminalServerRemoveSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyTerminalServerUpdatePolicy struct {
-	Policy *PolicyTerminalServerUpdatePolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyTerminalServerUpdatePolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyTerminalServerUpdatePolicy) GetPolicy() *PolicyTerminalServerUpdatePolicy_Policy {
 	if t == nil {
 		t = &PolicyTerminalServerUpdatePolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyTerminalServerUpdateRule struct {
-	Policy *PolicyTerminalServerUpdateRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyTerminalServerUpdateRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyTerminalServerUpdateRule) GetPolicy() *PolicyTerminalServerUpdateRule_Policy {
 	if t == nil {
 		t = &PolicyTerminalServerUpdateRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyTerminalServerUpdateSection struct {
-	Policy *PolicyTerminalServerUpdateSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyTerminalServerUpdateSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyTerminalServerUpdateSection) GetPolicy() *PolicyTerminalServerUpdateSection_Policy {
 	if t == nil {
 		t = &PolicyTerminalServerUpdateSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyTLSInspectAddRule struct {
-	Policy *PolicyTlsInspectAddRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyTlsInspectAddRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyTLSInspectAddRule) GetPolicy() *PolicyTlsInspectAddRule_Policy {
 	if t == nil {
 		t = &PolicyTLSInspectAddRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyTLSInspectAddSection struct {
-	Policy *PolicyTlsInspectAddSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyTlsInspectAddSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyTLSInspectAddSection) GetPolicy() *PolicyTlsInspectAddSection_Policy {
 	if t == nil {
 		t = &PolicyTLSInspectAddSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyTLSInspectCreatePolicyRevision struct {
-	Policy *PolicyTlsInspectCreatePolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyTlsInspectCreatePolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyTLSInspectCreatePolicyRevision) GetPolicy() *PolicyTlsInspectCreatePolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyTLSInspectCreatePolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyTLSInspectDiscardPolicyRevision struct {
-	Policy *PolicyTlsInspectDiscardPolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyTlsInspectDiscardPolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyTLSInspectDiscardPolicyRevision) GetPolicy() *PolicyTlsInspectDiscardPolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyTLSInspectDiscardPolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyTLSInspectMoveRule struct {
-	Policy *PolicyTlsInspectMoveRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyTlsInspectMoveRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyTLSInspectMoveRule) GetPolicy() *PolicyTlsInspectMoveRule_Policy {
 	if t == nil {
 		t = &PolicyTLSInspectMoveRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyTLSInspectMoveSection struct {
-	Policy *PolicyTlsInspectMoveSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyTlsInspectMoveSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyTLSInspectMoveSection) GetPolicy() *PolicyTlsInspectMoveSection_Policy {
 	if t == nil {
 		t = &PolicyTLSInspectMoveSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyTLSInspectPublishPolicyRevision struct {
-	Policy *PolicyTlsInspectPublishPolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyTlsInspectPublishPolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyTLSInspectPublishPolicyRevision) GetPolicy() *PolicyTlsInspectPublishPolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyTLSInspectPublishPolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyTLSInspectRemoveRule struct {
-	Policy *PolicyTlsInspectRemoveRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyTlsInspectRemoveRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyTLSInspectRemoveRule) GetPolicy() *PolicyTlsInspectRemoveRule_Policy {
 	if t == nil {
 		t = &PolicyTLSInspectRemoveRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyTLSInspectRemoveSection struct {
-	Policy *PolicyTlsInspectRemoveSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyTlsInspectRemoveSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyTLSInspectRemoveSection) GetPolicy() *PolicyTlsInspectRemoveSection_Policy {
 	if t == nil {
 		t = &PolicyTLSInspectRemoveSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyTLSInspectUpdatePolicy struct {
-	Policy *PolicyTlsInspectUpdatePolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyTlsInspectUpdatePolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyTLSInspectUpdatePolicy) GetPolicy() *PolicyTlsInspectUpdatePolicy_Policy {
 	if t == nil {
 		t = &PolicyTLSInspectUpdatePolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyTLSInspectUpdateRule struct {
-	Policy *PolicyTlsInspectUpdateRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyTlsInspectUpdateRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyTLSInspectUpdateRule) GetPolicy() *PolicyTlsInspectUpdateRule_Policy {
 	if t == nil {
 		t = &PolicyTLSInspectUpdateRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyTLSInspectUpdateSection struct {
-	Policy *PolicyTlsInspectUpdateSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyTlsInspectUpdateSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyTLSInspectUpdateSection) GetPolicy() *PolicyTlsInspectUpdateSection_Policy {
 	if t == nil {
 		t = &PolicyTLSInspectUpdateSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyWanFirewallAddRule struct {
-	Policy *PolicyWanFirewallAddRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyWanFirewallAddRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyWanFirewallAddRule) GetPolicy() *PolicyWanFirewallAddRule_Policy {
 	if t == nil {
 		t = &PolicyWanFirewallAddRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyWanFirewallAddSection struct {
-	Policy *PolicyWanFirewallAddSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyWanFirewallAddSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyWanFirewallAddSection) GetPolicy() *PolicyWanFirewallAddSection_Policy {
 	if t == nil {
 		t = &PolicyWanFirewallAddSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyWanFirewallAddSubPolicy struct {
-	Policy *PolicyWanFirewallAddSubPolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyWanFirewallAddSubPolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyWanFirewallAddSubPolicy) GetPolicy() *PolicyWanFirewallAddSubPolicy_Policy {
 	if t == nil {
 		t = &PolicyWanFirewallAddSubPolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyWanFirewallCreatePolicyRevision struct {
-	Policy *PolicyWanFirewallCreatePolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyWanFirewallCreatePolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyWanFirewallCreatePolicyRevision) GetPolicy() *PolicyWanFirewallCreatePolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyWanFirewallCreatePolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyWanFirewallDiscardPolicyRevision struct {
-	Policy *PolicyWanFirewallDiscardPolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyWanFirewallDiscardPolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyWanFirewallDiscardPolicyRevision) GetPolicy() *PolicyWanFirewallDiscardPolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyWanFirewallDiscardPolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyWanFirewallMoveRule struct {
-	Policy *PolicyWanFirewallMoveRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyWanFirewallMoveRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyWanFirewallMoveRule) GetPolicy() *PolicyWanFirewallMoveRule_Policy {
 	if t == nil {
 		t = &PolicyWanFirewallMoveRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyWanFirewallMoveSection struct {
-	Policy *PolicyWanFirewallMoveSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyWanFirewallMoveSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyWanFirewallMoveSection) GetPolicy() *PolicyWanFirewallMoveSection_Policy {
 	if t == nil {
 		t = &PolicyWanFirewallMoveSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyWanFirewallPublishPolicyRevision struct {
-	Policy *PolicyWanFirewallPublishPolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyWanFirewallPublishPolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyWanFirewallPublishPolicyRevision) GetPolicy() *PolicyWanFirewallPublishPolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyWanFirewallPublishPolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyWanFirewallRemoveRule struct {
-	Policy *PolicyWanFirewallRemoveRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyWanFirewallRemoveRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyWanFirewallRemoveRule) GetPolicy() *PolicyWanFirewallRemoveRule_Policy {
 	if t == nil {
 		t = &PolicyWanFirewallRemoveRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyWanFirewallRemoveSection struct {
-	Policy *PolicyWanFirewallRemoveSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyWanFirewallRemoveSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyWanFirewallRemoveSection) GetPolicy() *PolicyWanFirewallRemoveSection_Policy {
 	if t == nil {
 		t = &PolicyWanFirewallRemoveSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyWanFirewallRemoveSubPolicy struct {
-	Policy *PolicyWanFirewallRemoveSubPolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyWanFirewallRemoveSubPolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyWanFirewallRemoveSubPolicy) GetPolicy() *PolicyWanFirewallRemoveSubPolicy_Policy {
 	if t == nil {
 		t = &PolicyWanFirewallRemoveSubPolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyWanFirewallReorderPolicy struct {
-	Policy *PolicyWanFirewallReorderPolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyWanFirewallReorderPolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyWanFirewallReorderPolicy) GetPolicy() *PolicyWanFirewallReorderPolicy_Policy {
 	if t == nil {
 		t = &PolicyWanFirewallReorderPolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyWanFirewallUpdatePolicy struct {
-	Policy *PolicyWanFirewallUpdatePolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyWanFirewallUpdatePolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyWanFirewallUpdatePolicy) GetPolicy() *PolicyWanFirewallUpdatePolicy_Policy {
 	if t == nil {
 		t = &PolicyWanFirewallUpdatePolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyWanFirewallUpdateRule struct {
-	Policy *PolicyWanFirewallUpdateRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyWanFirewallUpdateRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyWanFirewallUpdateRule) GetPolicy() *PolicyWanFirewallUpdateRule_Policy {
 	if t == nil {
 		t = &PolicyWanFirewallUpdateRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyWanFirewallUpdateSection struct {
-	Policy *PolicyWanFirewallUpdateSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyWanFirewallUpdateSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyWanFirewallUpdateSection) GetPolicy() *PolicyWanFirewallUpdateSection_Policy {
 	if t == nil {
 		t = &PolicyWanFirewallUpdateSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyWanNetworkAddRule struct {
-	Policy *PolicyWanNetworkAddRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyWanNetworkAddRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyWanNetworkAddRule) GetPolicy() *PolicyWanNetworkAddRule_Policy {
 	if t == nil {
 		t = &PolicyWanNetworkAddRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyWanNetworkAddSection struct {
-	Policy *PolicyWanNetworkAddSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyWanNetworkAddSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyWanNetworkAddSection) GetPolicy() *PolicyWanNetworkAddSection_Policy {
 	if t == nil {
 		t = &PolicyWanNetworkAddSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyWanNetworkCreatePolicyRevision struct {
-	Policy *PolicyWanNetworkCreatePolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyWanNetworkCreatePolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyWanNetworkCreatePolicyRevision) GetPolicy() *PolicyWanNetworkCreatePolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyWanNetworkCreatePolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyWanNetworkDiscardPolicyRevision struct {
-	Policy *PolicyWanNetworkDiscardPolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyWanNetworkDiscardPolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyWanNetworkDiscardPolicyRevision) GetPolicy() *PolicyWanNetworkDiscardPolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyWanNetworkDiscardPolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyWanNetworkMoveRule struct {
-	Policy *PolicyWanNetworkMoveRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyWanNetworkMoveRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyWanNetworkMoveRule) GetPolicy() *PolicyWanNetworkMoveRule_Policy {
 	if t == nil {
 		t = &PolicyWanNetworkMoveRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyWanNetworkMoveSection struct {
-	Policy *PolicyWanNetworkMoveSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyWanNetworkMoveSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyWanNetworkMoveSection) GetPolicy() *PolicyWanNetworkMoveSection_Policy {
 	if t == nil {
 		t = &PolicyWanNetworkMoveSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyWanNetworkPublishPolicyRevision struct {
-	Policy *PolicyWanNetworkPublishPolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyWanNetworkPublishPolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyWanNetworkPublishPolicyRevision) GetPolicy() *PolicyWanNetworkPublishPolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyWanNetworkPublishPolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyWanNetworkRemoveRule struct {
-	Policy *PolicyWanNetworkRemoveRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyWanNetworkRemoveRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyWanNetworkRemoveRule) GetPolicy() *PolicyWanNetworkRemoveRule_Policy {
 	if t == nil {
 		t = &PolicyWanNetworkRemoveRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyWanNetworkRemoveSection struct {
-	Policy *PolicyWanNetworkRemoveSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyWanNetworkRemoveSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyWanNetworkRemoveSection) GetPolicy() *PolicyWanNetworkRemoveSection_Policy {
 	if t == nil {
 		t = &PolicyWanNetworkRemoveSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyWanNetworkReorderPolicy struct {
-	Policy *PolicyWanNetworkReorderPolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyWanNetworkReorderPolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyWanNetworkReorderPolicy) GetPolicy() *PolicyWanNetworkReorderPolicy_Policy {
 	if t == nil {
 		t = &PolicyWanNetworkReorderPolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyWanNetworkUpdatePolicy struct {
-	Policy *PolicyWanNetworkUpdatePolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyWanNetworkUpdatePolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyWanNetworkUpdatePolicy) GetPolicy() *PolicyWanNetworkUpdatePolicy_Policy {
 	if t == nil {
 		t = &PolicyWanNetworkUpdatePolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyWanNetworkUpdateRule struct {
-	Policy *PolicyWanNetworkUpdateRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyWanNetworkUpdateRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyWanNetworkUpdateRule) GetPolicy() *PolicyWanNetworkUpdateRule_Policy {
 	if t == nil {
 		t = &PolicyWanNetworkUpdateRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyWanNetworkUpdateSection struct {
-	Policy *PolicyWanNetworkUpdateSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyWanNetworkUpdateSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyWanNetworkUpdateSection) GetPolicy() *PolicyWanNetworkUpdateSection_Policy {
 	if t == nil {
 		t = &PolicyWanNetworkUpdateSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyZtnaAlwaysOnAddRule struct {
-	Policy *PolicyZtnaAlwaysOnAddRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyZtnaAlwaysOnAddRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyZtnaAlwaysOnAddRule) GetPolicy() *PolicyZtnaAlwaysOnAddRule_Policy {
 	if t == nil {
 		t = &PolicyZtnaAlwaysOnAddRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyZtnaAlwaysOnAddSection struct {
-	Policy *PolicyZtnaAlwaysOnAddSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyZtnaAlwaysOnAddSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyZtnaAlwaysOnAddSection) GetPolicy() *PolicyZtnaAlwaysOnAddSection_Policy {
 	if t == nil {
 		t = &PolicyZtnaAlwaysOnAddSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyZtnaAlwaysOnCreatePolicyRevision struct {
-	Policy *PolicyZtnaAlwaysOnCreatePolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyZtnaAlwaysOnCreatePolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyZtnaAlwaysOnCreatePolicyRevision) GetPolicy() *PolicyZtnaAlwaysOnCreatePolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyZtnaAlwaysOnCreatePolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyZtnaAlwaysOnDiscardPolicyRevision struct {
-	Policy *PolicyZtnaAlwaysOnDiscardPolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyZtnaAlwaysOnDiscardPolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyZtnaAlwaysOnDiscardPolicyRevision) GetPolicy() *PolicyZtnaAlwaysOnDiscardPolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyZtnaAlwaysOnDiscardPolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyZtnaAlwaysOnMoveRule struct {
-	Policy *PolicyZtnaAlwaysOnMoveRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyZtnaAlwaysOnMoveRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyZtnaAlwaysOnMoveRule) GetPolicy() *PolicyZtnaAlwaysOnMoveRule_Policy {
 	if t == nil {
 		t = &PolicyZtnaAlwaysOnMoveRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyZtnaAlwaysOnMoveSection struct {
-	Policy *PolicyZtnaAlwaysOnMoveSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyZtnaAlwaysOnMoveSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyZtnaAlwaysOnMoveSection) GetPolicy() *PolicyZtnaAlwaysOnMoveSection_Policy {
 	if t == nil {
 		t = &PolicyZtnaAlwaysOnMoveSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyZtnaAlwaysOnPublishPolicyRevision struct {
-	Policy *PolicyZtnaAlwaysOnPublishPolicyRevision_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyZtnaAlwaysOnPublishPolicyRevision_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyZtnaAlwaysOnPublishPolicyRevision) GetPolicy() *PolicyZtnaAlwaysOnPublishPolicyRevision_Policy {
 	if t == nil {
 		t = &PolicyZtnaAlwaysOnPublishPolicyRevision{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyZtnaAlwaysOnRemoveRule struct {
-	Policy *PolicyZtnaAlwaysOnRemoveRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyZtnaAlwaysOnRemoveRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyZtnaAlwaysOnRemoveRule) GetPolicy() *PolicyZtnaAlwaysOnRemoveRule_Policy {
 	if t == nil {
 		t = &PolicyZtnaAlwaysOnRemoveRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyZtnaAlwaysOnRemoveSection struct {
-	Policy *PolicyZtnaAlwaysOnRemoveSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyZtnaAlwaysOnRemoveSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyZtnaAlwaysOnRemoveSection) GetPolicy() *PolicyZtnaAlwaysOnRemoveSection_Policy {
 	if t == nil {
 		t = &PolicyZtnaAlwaysOnRemoveSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyZtnaAlwaysOnUpdatePolicy struct {
-	Policy *PolicyZtnaAlwaysOnUpdatePolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyZtnaAlwaysOnUpdatePolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyZtnaAlwaysOnUpdatePolicy) GetPolicy() *PolicyZtnaAlwaysOnUpdatePolicy_Policy {
 	if t == nil {
 		t = &PolicyZtnaAlwaysOnUpdatePolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyZtnaAlwaysOnUpdateRule struct {
-	Policy *PolicyZtnaAlwaysOnUpdateRule_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyZtnaAlwaysOnUpdateRule_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyZtnaAlwaysOnUpdateRule) GetPolicy() *PolicyZtnaAlwaysOnUpdateRule_Policy {
 	if t == nil {
 		t = &PolicyZtnaAlwaysOnUpdateRule{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyZtnaAlwaysOnUpdateSection struct {
-	Policy *PolicyZtnaAlwaysOnUpdateSection_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyZtnaAlwaysOnUpdateSection_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyZtnaAlwaysOnUpdateSection) GetPolicy() *PolicyZtnaAlwaysOnUpdateSection_Policy {
 	if t == nil {
 		t = &PolicyZtnaAlwaysOnUpdateSection{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PopLocationMutationsAddAllocatedIP struct {
@@ -231143,234 +231143,234 @@ func (t *Object) GetObject() *Object_Object {
 }
 
 type PolicyAntiMalwareFileHashPolicy struct {
-	Policy *PolicyAntiMalwareFileHashPolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyAntiMalwareFileHashPolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyAntiMalwareFileHashPolicy) GetPolicy() *PolicyAntiMalwareFileHashPolicy_Policy {
 	if t == nil {
 		t = &PolicyAntiMalwareFileHashPolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type AppTenantRestrictionPolicy struct {
-	Policy *AppTenantRestrictionPolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy AppTenantRestrictionPolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *AppTenantRestrictionPolicy) GetPolicy() *AppTenantRestrictionPolicy_Policy {
 	if t == nil {
 		t = &AppTenantRestrictionPolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type ApplicationControlPolicy struct {
-	Policy *ApplicationControlPolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy ApplicationControlPolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *ApplicationControlPolicy) GetPolicy() *ApplicationControlPolicy_Policy {
 	if t == nil {
 		t = &ApplicationControlPolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyClientConnectivityPolicy struct {
-	Policy *PolicyClientConnectivityPolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyClientConnectivityPolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyClientConnectivityPolicy) GetPolicy() *PolicyClientConnectivityPolicy_Policy {
 	if t == nil {
 		t = &PolicyClientConnectivityPolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyDynamicIPAllocationPolicy struct {
-	Policy *PolicyDynamicIpAllocationPolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyDynamicIpAllocationPolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyDynamicIPAllocationPolicy) GetPolicy() *PolicyDynamicIpAllocationPolicy_Policy {
 	if t == nil {
 		t = &PolicyDynamicIPAllocationPolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type Policy struct {
-	Policy *Policy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy Policy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *Policy) GetPolicy() *Policy_Policy {
 	if t == nil {
 		t = &Policy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type InternetFirewallPolicy struct {
-	Policy *InternetFirewallPolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy InternetFirewallPolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *InternetFirewallPolicy) GetPolicy() *InternetFirewallPolicy_Policy {
 	if t == nil {
 		t = &InternetFirewallPolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyInternetFirewallPolicyList struct {
-	Policy *PolicyInternetFirewallPolicyList_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyInternetFirewallPolicyList_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyInternetFirewallPolicyList) GetPolicy() *PolicyInternetFirewallPolicyList_Policy {
 	if t == nil {
 		t = &PolicyInternetFirewallPolicyList{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyReadPrivateAccessPolicy struct {
-	Policy *PolicyReadPrivateAccessPolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyReadPrivateAccessPolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyReadPrivateAccessPolicy) GetPolicy() *PolicyReadPrivateAccessPolicy_Policy {
 	if t == nil {
 		t = &PolicyReadPrivateAccessPolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyRemotePortFwd struct {
-	Policy *PolicyRemotePortFwd_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyRemotePortFwd_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyRemotePortFwd) GetPolicy() *PolicyRemotePortFwd_Policy {
 	if t == nil {
 		t = &PolicyRemotePortFwd{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type RemotePortFwdPolicy struct {
-	Policy *RemotePortFwdPolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy RemotePortFwdPolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *RemotePortFwdPolicy) GetPolicy() *RemotePortFwdPolicy_Policy {
 	if t == nil {
 		t = &RemotePortFwdPolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySocketBypassPolicy struct {
-	Policy *PolicySocketBypassPolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySocketBypassPolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySocketBypassPolicy) GetPolicy() *PolicySocketBypassPolicy_Policy {
 	if t == nil {
 		t = &PolicySocketBypassPolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySocketLanPolicy struct {
-	Policy *PolicySocketLanPolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySocketLanPolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySocketLanPolicy) GetPolicy() *PolicySocketLanPolicy_Policy {
 	if t == nil {
 		t = &PolicySocketLanPolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySocketLanPolicyList struct {
-	Policy *PolicySocketLanPolicyList_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySocketLanPolicyList_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySocketLanPolicyList) GetPolicy() *PolicySocketLanPolicyList_Policy {
 	if t == nil {
 		t = &PolicySocketLanPolicyList{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicySplitTunnelPolicy struct {
-	Policy *PolicySplitTunnelPolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicySplitTunnelPolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicySplitTunnelPolicy) GetPolicy() *PolicySplitTunnelPolicy_Policy {
 	if t == nil {
 		t = &PolicySplitTunnelPolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyTerminalServerPolicy struct {
-	Policy *PolicyTerminalServerPolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyTerminalServerPolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyTerminalServerPolicy) GetPolicy() *PolicyTerminalServerPolicy_Policy {
 	if t == nil {
 		t = &PolicyTerminalServerPolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type Tlsinspectpolicy struct {
-	Policy *Tlsinspectpolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy Tlsinspectpolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *Tlsinspectpolicy) GetPolicy() *Tlsinspectpolicy_Policy {
 	if t == nil {
 		t = &Tlsinspectpolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type WanFirewallPolicy struct {
-	Policy *WanFirewallPolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy WanFirewallPolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *WanFirewallPolicy) GetPolicy() *WanFirewallPolicy_Policy {
 	if t == nil {
 		t = &WanFirewallPolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyWanFirewallPolicyList struct {
-	Policy *PolicyWanFirewallPolicyList_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyWanFirewallPolicyList_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyWanFirewallPolicyList) GetPolicy() *PolicyWanFirewallPolicyList_Policy {
 	if t == nil {
 		t = &PolicyWanFirewallPolicyList{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type WanNetworkPolicy struct {
-	Policy *WanNetworkPolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy WanNetworkPolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *WanNetworkPolicy) GetPolicy() *WanNetworkPolicy_Policy {
 	if t == nil {
 		t = &WanNetworkPolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PolicyZtnaAlwaysOnPolicy struct {
-	Policy *PolicyZtnaAlwaysOnPolicy_Policy "json:\"policy,omitempty\" graphql:\"policy\""
+	Policy PolicyZtnaAlwaysOnPolicy_Policy "json:\"policy\" graphql:\"policy\""
 }
 
 func (t *PolicyZtnaAlwaysOnPolicy) GetPolicy() *PolicyZtnaAlwaysOnPolicy_Policy {
 	if t == nil {
 		t = &PolicyZtnaAlwaysOnPolicy{}
 	}
-	return t.Policy
+	return &t.Policy
 }
 
 type PopLocations struct {

--- a/models/models.go
+++ b/models/models.go
@@ -478,15 +478,6 @@ type AccessRequestTypeFilterInput struct {
 	Nin []ExternalAccessRequestType `json:"nin,omitempty"`
 }
 
-type AccessTokenRef struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-}
-
-func (AccessTokenRef) IsObjectRef()         {}
-func (this AccessTokenRef) GetID() string   { return this.ID }
-func (this AccessTokenRef) GetName() string { return this.Name }
-
 type AccountAuditData struct {
 	CreatedBy   string `json:"createdBy"`
 	CreatedTime string `json:"createdTime"`
@@ -3341,6 +3332,7 @@ func (this CasbLicense) GetStatus() LicenseStatus  { return this.Status }
 type CatalogApplication struct {
 	Activity                           []*CatalogApplicationActivity                         `json:"activity"`
 	AiSecurity                         *AiSecurityAttributes                                 `json:"aiSecurity,omitempty"`
+	Asn                                []scalars.Asn32                                       `json:"asn"`
 	Capability                         []CatalogApplicationCapability                        `json:"capability"`
 	Category                           []*ApplicationCategoryRef                             `json:"category"`
 	ChildApp                           []*ApplicationRef                                     `json:"childApp"`
@@ -3348,6 +3340,7 @@ type CatalogApplication struct {
 	ComplianceAttributes               *CatalogApplicationComplianceAttributes               `json:"complianceAttributes"`
 	Description                        *string                                               `json:"description,omitempty"`
 	DescriptionSummary                 *string                                               `json:"descriptionSummary,omitempty"`
+	DynamicIPSource                    []string                                              `json:"dynamicIpSource"`
 	Fqdn                               []string                                              `json:"fqdn"`
 	ID                                 string                                                `json:"id"`
 	IdentityAccessManagementAttributes *CatalogApplicationIdentityAccessManagementAttributes `json:"identityAccessManagementAttributes,omitempty"`
@@ -3362,6 +3355,7 @@ type CatalogApplication struct {
 	Sanctioned                         bool                                                  `json:"sanctioned"`
 	SecurityAttributes                 *CatalogApplicationSecurityAttributes                 `json:"securityAttributes"`
 	StandardPorts                      []*CustomService                                      `json:"standardPorts"`
+	StaticIPRange                      []string                                              `json:"staticIpRange"`
 	TenantActivity                     []*CatalogApplicationActivity                         `json:"tenantActivity"`
 	Type                               CatalogApplicationType                                `json:"type"`
 	Website                            *string                                               `json:"website,omitempty"`
@@ -5673,6 +5667,14 @@ type EnableUserInput struct {
 // Response payload for the enableUser mutation.
 type EnableUserPayload struct {
 	Users []*User `json:"users"`
+}
+
+type EncryptKeytabFileInput struct {
+	File graphql.Upload `json:"file"`
+}
+
+type EncryptKeytabFilePayload struct {
+	EncryptedFile string `json:"encryptedFile"`
 }
 
 // End Point Protection (EPP) license details
@@ -8933,6 +8935,16 @@ type NetworkConfigDhcpOptionUpsertInput struct {
 	Value       string                      `json:"value"`
 }
 
+// A reference to an existing DHCP profile.
+type NetworkConfigDhcpProfileRef struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func (NetworkConfigDhcpProfileRef) IsObjectRef()         {}
+func (this NetworkConfigDhcpProfileRef) GetID() string   { return this.ID }
+func (this NetworkConfigDhcpProfileRef) GetName() string { return this.Name }
+
 // DHCP read operations for the account.
 type NetworkConfigDhcpQueries struct {
 	Option         *NetworkConfigDhcpOption                `json:"option,omitempty"`
@@ -9264,6 +9276,16 @@ type NetworkConfigDNSServerSetListPayload struct {
 	Paging *PageInfo                    `json:"paging"`
 }
 
+// A reference to an existing DNS server set.
+type NetworkConfigDNSServerSetRef struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func (NetworkConfigDNSServerSetRef) IsObjectRef()         {}
+func (this NetworkConfigDNSServerSetRef) GetID() string   { return this.ID }
+func (this NetworkConfigDNSServerSetRef) GetName() string { return this.Name }
+
 // A reference to an existing DNS server set, by id or name.
 type NetworkConfigDNSServerSetRefInput struct {
 	By    ObjectRefBy `json:"by"`
@@ -9375,6 +9397,16 @@ type NetworkConfigDNSSuffixSetListPayload struct {
 	Paging *PageInfo                    `json:"paging"`
 }
 
+// A reference to an existing DNS suffix set.
+type NetworkConfigDNSSuffixSetRef struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func (NetworkConfigDNSSuffixSetRef) IsObjectRef()         {}
+func (this NetworkConfigDNSSuffixSetRef) GetID() string   { return this.ID }
+func (this NetworkConfigDNSSuffixSetRef) GetName() string { return this.Name }
+
 // A reference to an existing DNS suffix set, by id or name.
 type NetworkConfigDNSSuffixSetRefInput struct {
 	By    ObjectRefBy `json:"by"`
@@ -9464,6 +9496,16 @@ type NetworkConfigQueries struct {
 	Dhcp *NetworkConfigDhcpQueries `json:"dhcp"`
 	DNS  *NetworkConfigDNSQueries  `json:"dns"`
 }
+
+// A reference to an existing SNMP profile.
+type NetworkConfigSnmpProfileRef struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func (NetworkConfigSnmpProfileRef) IsObjectRef()         {}
+func (this NetworkConfigSnmpProfileRef) GetID() string   { return this.ID }
+func (this NetworkConfigSnmpProfileRef) GetName() string { return this.Name }
 
 type NetworkDhcpSettingsInput struct {
 	DhcpMicrosegmentation *bool    `json:"dhcpMicrosegmentation,omitempty"`
@@ -10005,6 +10047,7 @@ type PolicyMutations struct {
 	InternetFirewall     *InternetFirewallPolicyMutations     `json:"internetFirewall,omitempty"`
 	PrivateAccess        *PrivateAccessPolicyMutations        `json:"privateAccess,omitempty"`
 	RemotePortFwd        *RemotePortFwdPolicyMutations        `json:"remotePortFwd,omitempty"`
+	SiteWebProxy         *SiteWebProxyPolicyMutations         `json:"siteWebProxy,omitempty"`
 	SocketBypass         *SocketBypassPolicyMutations         `json:"socketBypass,omitempty"`
 	SocketLan            *SocketLanPolicyMutations            `json:"socketLan,omitempty"`
 	SplitTunnel          *SplitTunnelPolicyMutations          `json:"splitTunnel,omitempty"`
@@ -10034,6 +10077,7 @@ type PolicyQueries struct {
 	InternetFirewall     *InternetFirewallPolicyQueries     `json:"internetFirewall,omitempty"`
 	PrivateAccess        *PrivateAccessPolicyQueries        `json:"privateAccess,omitempty"`
 	RemotePortFwd        *RemotePortFwdPolicyQueries        `json:"remotePortFwd,omitempty"`
+	SiteWebProxy         *SiteWebProxyPolicyQueries         `json:"siteWebProxy,omitempty"`
 	SocketBypass         *SocketBypassPolicyQueries         `json:"socketBypass,omitempty"`
 	SocketLan            *SocketLanPolicyQueries            `json:"socketLan,omitempty"`
 	SplitTunnel          *SplitTunnelPolicyQueries          `json:"splitTunnel,omitempty"`
@@ -10498,9 +10542,10 @@ type PopLocationUpdateAllocatedIPDescriptionPayload struct {
 }
 
 type PopLocationUpdateBgpProfileInput struct {
-	Description *string `json:"description,omitempty"`
-	ID          string  `json:"id"`
-	Name        *string `json:"name,omitempty"`
+	Communities []*BgpCommunityInput `json:"communities,omitempty"`
+	Description *string              `json:"description,omitempty"`
+	ID          string               `json:"id"`
+	Name        *string              `json:"name,omitempty"`
 }
 
 type PopLocationUpdateBgpProfilePayload struct {
@@ -12064,6 +12109,389 @@ type SiteUpgradeRequest struct {
 
 type SiteUpgradeScheduleInput struct {
 	Time string `json:"time"`
+}
+
+type SiteWebProxyAddRuleDataInput struct {
+	AssociatedSite              []*SiteRefInput                        `json:"associatedSite"`
+	AuthenticationConfig        *SiteWebProxyAuthenticationConfigInput `json:"authenticationConfig"`
+	Description                 string                                 `json:"description"`
+	Enabled                     bool                                   `json:"enabled"`
+	Fqdn                        string                                 `json:"fqdn"`
+	Name                        string                                 `json:"name"`
+	Port                        scalars.Port                           `json:"port"`
+	ShouldAssociateWithAllSites bool                                   `json:"shouldAssociateWithAllSites"`
+}
+
+type SiteWebProxyAddRuleInput struct {
+	At   *PolicyRulePositionInput      `json:"at,omitempty"`
+	Rule *SiteWebProxyAddRuleDataInput `json:"rule"`
+}
+
+// Authentication configuration for the web proxy, including any required protocol-specific settings.
+type SiteWebProxyAuthenticationConfig struct {
+	KerberosConfig *SiteWebProxyKerberosConfig `json:"kerberosConfig,omitempty"`
+	Method         *SiteWebProxyAuthMethod     `json:"method,omitempty"`
+}
+
+// Authentication configuration for the web proxy, including any required protocol-specific settings.
+type SiteWebProxyAuthenticationConfigInput struct {
+	KerberosConfig *SiteWebProxyKerberosConfigInput `json:"kerberosConfig,omitempty"`
+	Method         *SiteWebProxyAuthMethod          `json:"method,omitempty"`
+}
+
+// Authentication configuration for the web proxy, including any required protocol-specific settings.
+type SiteWebProxyAuthenticationConfigUpdateInput struct {
+	KerberosConfig *SiteWebProxyKerberosConfigUpdateInput `json:"kerberosConfig,omitempty"`
+	Method         *SiteWebProxyAuthMethod                `json:"method,omitempty"`
+}
+
+// Destination criteria matched by a web proxy traffic rule. To specify 'ANY' destination, an empty list must be provided for each match criteria field (e.g. fqdn: [], ip: []).
+type SiteWebProxyDestination struct {
+	Domain []string `json:"domain"`
+	Fqdn   []string `json:"fqdn"`
+	IP     []string `json:"ip"`
+}
+
+// Destination criteria matched by a web proxy traffic rule. To specify 'ANY' destination, an empty list must be provided for each match criteria field (e.g. fqdn: [], ip: []).
+type SiteWebProxyDestinationInput struct {
+	Domain []string `json:"domain"`
+	Fqdn   []string `json:"fqdn"`
+	IP     []string `json:"ip"`
+}
+
+// Destination criteria matched by a web proxy traffic rule. To specify 'ANY' destination, an empty list must be provided for each match criteria field (e.g. fqdn: [], ip: []).
+type SiteWebProxyDestinationUpdateInput struct {
+	Domain []string `json:"domain,omitempty"`
+	Fqdn   []string `json:"fqdn,omitempty"`
+	IP     []string `json:"ip,omitempty"`
+}
+
+// Kerberos authentication settings for the web proxy.
+type SiteWebProxyKerberosConfig struct {
+	EncryptedKeytab *string `json:"encryptedKeytab,omitempty"`
+	IsEnabled       bool    `json:"isEnabled"`
+}
+
+// Kerberos authentication settings for the web proxy.
+type SiteWebProxyKerberosConfigInput struct {
+	EncryptedKeytab *string `json:"encryptedKeytab,omitempty"`
+	IsEnabled       bool    `json:"isEnabled"`
+}
+
+// Kerberos authentication settings for the web proxy.
+type SiteWebProxyKerberosConfigUpdateInput struct {
+	EncryptedKeytab *string `json:"encryptedKeytab,omitempty"`
+	IsEnabled       *bool   `json:"isEnabled,omitempty"`
+}
+
+type SiteWebProxyPolicy struct {
+	Audit    *PolicyAudit               `json:"audit,omitempty"`
+	Enabled  bool                       `json:"enabled"`
+	Revision *PolicyRevision            `json:"revision,omitempty"`
+	Rules    []*SiteWebProxyRulePayload `json:"rules"`
+	Sections []*PolicySectionPayload    `json:"sections"`
+}
+
+func (SiteWebProxyPolicy) IsIPolicy()                        {}
+func (this SiteWebProxyPolicy) GetAudit() *PolicyAudit       { return this.Audit }
+func (this SiteWebProxyPolicy) GetEnabled() bool             { return this.Enabled }
+func (this SiteWebProxyPolicy) GetRevision() *PolicyRevision { return this.Revision }
+func (this SiteWebProxyPolicy) GetRules() []IPolicyRulePayload {
+	if this.Rules == nil {
+		return nil
+	}
+	interfaceSlice := make([]IPolicyRulePayload, 0, len(this.Rules))
+	for _, concrete := range this.Rules {
+		interfaceSlice = append(interfaceSlice, concrete)
+	}
+	return interfaceSlice
+}
+func (this SiteWebProxyPolicy) GetSections() []*PolicySectionPayload {
+	if this.Sections == nil {
+		return nil
+	}
+	interfaceSlice := make([]*PolicySectionPayload, 0, len(this.Sections))
+	for _, concrete := range this.Sections {
+		interfaceSlice = append(interfaceSlice, concrete)
+	}
+	return interfaceSlice
+}
+
+type SiteWebProxyPolicyInput struct {
+	Revision *PolicyRevisionInput `json:"revision,omitempty"`
+}
+
+type SiteWebProxyPolicyMutationInput struct {
+	Revision *PolicyMutationRevisionInput `json:"revision,omitempty"`
+}
+
+type SiteWebProxyPolicyMutationPayload struct {
+	Errors []*PolicyMutationError `json:"errors"`
+	Policy *SiteWebProxyPolicy    `json:"policy,omitempty"`
+	Status PolicyMutationStatus   `json:"status"`
+}
+
+func (SiteWebProxyPolicyMutationPayload) IsIPolicyMutationPayload() {}
+func (this SiteWebProxyPolicyMutationPayload) GetErrors() []*PolicyMutationError {
+	if this.Errors == nil {
+		return nil
+	}
+	interfaceSlice := make([]*PolicyMutationError, 0, len(this.Errors))
+	for _, concrete := range this.Errors {
+		interfaceSlice = append(interfaceSlice, concrete)
+	}
+	return interfaceSlice
+}
+func (this SiteWebProxyPolicyMutationPayload) GetPolicy() IPolicy              { return *this.Policy }
+func (this SiteWebProxyPolicyMutationPayload) GetStatus() PolicyMutationStatus { return this.Status }
+
+type SiteWebProxyPolicyMutations struct {
+	AddRule               *SiteWebProxyRuleMutationPayload    `json:"addRule"`
+	AddSection            *PolicySectionMutationPayload       `json:"addSection"`
+	CreatePolicyRevision  *SiteWebProxyPolicyMutationPayload  `json:"createPolicyRevision"`
+	DiscardPolicyRevision *SiteWebProxyPolicyMutationPayload  `json:"discardPolicyRevision"`
+	MoveRule              *SiteWebProxyRuleMutationPayload    `json:"moveRule"`
+	MoveSection           *PolicySectionMutationPayload       `json:"moveSection"`
+	PublishPolicyRevision *SiteWebProxyPolicyMutationPayload  `json:"publishPolicyRevision"`
+	RemoveRule            *SiteWebProxyRuleMutationPayload    `json:"removeRule"`
+	RemoveSection         *PolicySectionMutationPayload       `json:"removeSection"`
+	UpdatePolicy          *SiteWebProxyPolicyMutationPayload  `json:"updatePolicy"`
+	UpdateRule            *SiteWebProxyRuleMutationPayload    `json:"updateRule"`
+	UpdateSection         *PolicySectionMutationPayload       `json:"updateSection"`
+	WebProxyTraffic       *SiteWebProxyTrafficPolicyMutations `json:"webProxyTraffic"`
+}
+
+type SiteWebProxyPolicyQueries struct {
+	Policy    *SiteWebProxyPolicy     `json:"policy"`
+	Revisions *PolicyRevisionsPayload `json:"revisions,omitempty"`
+}
+
+type SiteWebProxyPolicyUpdateInput struct {
+	State *PolicyToggleState `json:"state,omitempty"`
+}
+
+type SiteWebProxyRemoveRuleInput struct {
+	ID string `json:"id"`
+}
+
+type SiteWebProxyRule struct {
+	AssociatedSite              []*SiteRef                        `json:"associatedSite"`
+	AuthenticationConfig        *SiteWebProxyAuthenticationConfig `json:"authenticationConfig"`
+	Description                 string                            `json:"description"`
+	Enabled                     bool                              `json:"enabled"`
+	Fqdn                        string                            `json:"fqdn"`
+	ID                          string                            `json:"id"`
+	Index                       int64                             `json:"index"`
+	Name                        string                            `json:"name"`
+	Port                        scalars.Port                      `json:"port"`
+	Section                     *PolicySectionInfo                `json:"section"`
+	ShouldAssociateWithAllSites bool                              `json:"shouldAssociateWithAllSites"`
+	WebProxyTraffic             []*SiteWebProxyTrafficRulePayload `json:"webProxyTraffic"`
+}
+
+func (SiteWebProxyRule) IsIPolicyRule()                      {}
+func (this SiteWebProxyRule) GetDescription() *string        { return &this.Description }
+func (this SiteWebProxyRule) GetEnabled() bool               { return this.Enabled }
+func (this SiteWebProxyRule) GetID() string                  { return this.ID }
+func (this SiteWebProxyRule) GetIndex() int64                { return this.Index }
+func (this SiteWebProxyRule) GetName() string                { return this.Name }
+func (this SiteWebProxyRule) GetSection() *PolicySectionInfo { return this.Section }
+
+type SiteWebProxyRuleMutationPayload struct {
+	Errors   []*PolicyMutationError   `json:"errors"`
+	Revision *PolicyRevision          `json:"revision,omitempty"`
+	Rule     *SiteWebProxyRulePayload `json:"rule,omitempty"`
+	Status   PolicyMutationStatus     `json:"status"`
+}
+
+func (SiteWebProxyRuleMutationPayload) IsIPolicyRuleMutationPayload() {}
+func (this SiteWebProxyRuleMutationPayload) GetErrors() []*PolicyMutationError {
+	if this.Errors == nil {
+		return nil
+	}
+	interfaceSlice := make([]*PolicyMutationError, 0, len(this.Errors))
+	for _, concrete := range this.Errors {
+		interfaceSlice = append(interfaceSlice, concrete)
+	}
+	return interfaceSlice
+}
+func (this SiteWebProxyRuleMutationPayload) GetRule() IPolicyRulePayload     { return *this.Rule }
+func (this SiteWebProxyRuleMutationPayload) GetStatus() PolicyMutationStatus { return this.Status }
+
+type SiteWebProxyRulePayload struct {
+	Audit      *PolicyElementAudit           `json:"audit"`
+	Metadata   *PolicyElementMetadata        `json:"metadata,omitempty"`
+	Properties []PolicyElementPropertiesEnum `json:"properties"`
+	Rule       *SiteWebProxyRule             `json:"rule"`
+}
+
+func (SiteWebProxyRulePayload) IsIPolicyRulePayload()              {}
+func (this SiteWebProxyRulePayload) GetAudit() *PolicyElementAudit { return this.Audit }
+func (this SiteWebProxyRulePayload) GetProperties() []PolicyElementPropertiesEnum {
+	if this.Properties == nil {
+		return nil
+	}
+	interfaceSlice := make([]PolicyElementPropertiesEnum, 0, len(this.Properties))
+	for _, concrete := range this.Properties {
+		interfaceSlice = append(interfaceSlice, concrete)
+	}
+	return interfaceSlice
+}
+func (this SiteWebProxyRulePayload) GetRule() IPolicyRule { return *this.Rule }
+
+// Source criteria matched by a web proxy traffic rule. To specify 'ANY' source, an empty list must be provided for each match criteria field (e.g. ip: [], site: [], etc...).
+type SiteWebProxySource struct {
+	GlobalIPRange     []*GlobalIPRangeRef     `json:"globalIpRange"`
+	Group             []*GroupRef             `json:"group"`
+	IP                []string                `json:"ip"`
+	IPRange           []*IPAddressRange       `json:"ipRange"`
+	NetworkInterface  []*NetworkInterfaceRef  `json:"networkInterface"`
+	Site              []*SiteRef              `json:"site"`
+	SiteNetworkSubnet []*SiteNetworkSubnetRef `json:"siteNetworkSubnet"`
+	Subnet            []string                `json:"subnet"`
+}
+
+// Source criteria matched by a web proxy traffic rule. To specify 'ANY' source, an empty list must be provided for each match criteria field (e.g. ip: [], site: [], etc...).
+type SiteWebProxySourceInput struct {
+	GlobalIPRange     []*GlobalIPRangeRefInput     `json:"globalIpRange"`
+	Group             []*GroupRefInput             `json:"group"`
+	IP                []string                     `json:"ip"`
+	IPRange           []*IPAddressRangeInput       `json:"ipRange"`
+	NetworkInterface  []*NetworkInterfaceRefInput  `json:"networkInterface"`
+	Site              []*SiteRefInput              `json:"site"`
+	SiteNetworkSubnet []*SiteNetworkSubnetRefInput `json:"siteNetworkSubnet"`
+	Subnet            []string                     `json:"subnet"`
+}
+
+// Source criteria matched by a web proxy traffic rule. To specify 'ANY' source, an empty list must be provided for each match criteria field (e.g. ip: [], site: [], etc...).
+type SiteWebProxySourceUpdateInput struct {
+	GlobalIPRange     []*GlobalIPRangeRefInput     `json:"globalIpRange,omitempty"`
+	Group             []*GroupRefInput             `json:"group,omitempty"`
+	IP                []string                     `json:"ip,omitempty"`
+	IPRange           []*IPAddressRangeInput       `json:"ipRange,omitempty"`
+	NetworkInterface  []*NetworkInterfaceRefInput  `json:"networkInterface,omitempty"`
+	Site              []*SiteRefInput              `json:"site,omitempty"`
+	SiteNetworkSubnet []*SiteNetworkSubnetRefInput `json:"siteNetworkSubnet,omitempty"`
+	Subnet            []string                     `json:"subnet,omitempty"`
+}
+
+type SiteWebProxyTrafficAddRuleDataInput struct {
+	Action      SiteWebProxyAction            `json:"action"`
+	Description string                        `json:"description"`
+	Destination *SiteWebProxyDestinationInput `json:"destination"`
+	Enabled     bool                          `json:"enabled"`
+	Name        string                        `json:"name"`
+	Source      *SiteWebProxySourceInput      `json:"source"`
+}
+
+type SiteWebProxyTrafficAddRuleInput struct {
+	At   *PolicySubRulePositionInput          `json:"at,omitempty"`
+	Rule *SiteWebProxyTrafficAddRuleDataInput `json:"rule"`
+}
+
+type SiteWebProxyTrafficPolicyMutations struct {
+	AddRule    *SiteWebProxyTrafficRuleMutationPayload `json:"addRule"`
+	MoveRule   *SiteWebProxyTrafficRuleMutationPayload `json:"moveRule"`
+	RemoveRule *SiteWebProxyTrafficRuleMutationPayload `json:"removeRule"`
+	UpdateRule *SiteWebProxyTrafficRuleMutationPayload `json:"updateRule"`
+}
+
+type SiteWebProxyTrafficRemoveRuleInput struct {
+	ID string `json:"id"`
+}
+
+type SiteWebProxyTrafficRule struct {
+	Action      SiteWebProxyAction       `json:"action"`
+	Description string                   `json:"description"`
+	Destination *SiteWebProxyDestination `json:"destination"`
+	Enabled     bool                     `json:"enabled"`
+	ID          string                   `json:"id"`
+	Index       int64                    `json:"index"`
+	Name        string                   `json:"name"`
+	Section     *PolicySectionInfo       `json:"section,omitempty"`
+	Source      *SiteWebProxySource      `json:"source"`
+}
+
+func (SiteWebProxyTrafficRule) IsIPolicyRule()                      {}
+func (this SiteWebProxyTrafficRule) GetDescription() *string        { return &this.Description }
+func (this SiteWebProxyTrafficRule) GetEnabled() bool               { return this.Enabled }
+func (this SiteWebProxyTrafficRule) GetID() string                  { return this.ID }
+func (this SiteWebProxyTrafficRule) GetIndex() int64                { return this.Index }
+func (this SiteWebProxyTrafficRule) GetName() string                { return this.Name }
+func (this SiteWebProxyTrafficRule) GetSection() *PolicySectionInfo { return this.Section }
+
+type SiteWebProxyTrafficRuleMutationPayload struct {
+	Errors   []*PolicyMutationError          `json:"errors"`
+	Revision *PolicyRevision                 `json:"revision,omitempty"`
+	Rule     *SiteWebProxyTrafficRulePayload `json:"rule,omitempty"`
+	Status   PolicyMutationStatus            `json:"status"`
+}
+
+func (SiteWebProxyTrafficRuleMutationPayload) IsIPolicyRuleMutationPayload() {}
+func (this SiteWebProxyTrafficRuleMutationPayload) GetErrors() []*PolicyMutationError {
+	if this.Errors == nil {
+		return nil
+	}
+	interfaceSlice := make([]*PolicyMutationError, 0, len(this.Errors))
+	for _, concrete := range this.Errors {
+		interfaceSlice = append(interfaceSlice, concrete)
+	}
+	return interfaceSlice
+}
+func (this SiteWebProxyTrafficRuleMutationPayload) GetRule() IPolicyRulePayload { return *this.Rule }
+func (this SiteWebProxyTrafficRuleMutationPayload) GetStatus() PolicyMutationStatus {
+	return this.Status
+}
+
+type SiteWebProxyTrafficRulePayload struct {
+	Audit      *PolicyElementAudit           `json:"audit"`
+	Metadata   *PolicyElementMetadata        `json:"metadata,omitempty"`
+	Properties []PolicyElementPropertiesEnum `json:"properties"`
+	Rule       *SiteWebProxyTrafficRule      `json:"rule"`
+}
+
+func (SiteWebProxyTrafficRulePayload) IsIPolicyRulePayload()              {}
+func (this SiteWebProxyTrafficRulePayload) GetAudit() *PolicyElementAudit { return this.Audit }
+func (this SiteWebProxyTrafficRulePayload) GetProperties() []PolicyElementPropertiesEnum {
+	if this.Properties == nil {
+		return nil
+	}
+	interfaceSlice := make([]PolicyElementPropertiesEnum, 0, len(this.Properties))
+	for _, concrete := range this.Properties {
+		interfaceSlice = append(interfaceSlice, concrete)
+	}
+	return interfaceSlice
+}
+func (this SiteWebProxyTrafficRulePayload) GetRule() IPolicyRule { return *this.Rule }
+
+type SiteWebProxyTrafficUpdateRuleDataInput struct {
+	Action      *SiteWebProxyAction                 `json:"action,omitempty"`
+	Description *string                             `json:"description,omitempty"`
+	Destination *SiteWebProxyDestinationUpdateInput `json:"destination,omitempty"`
+	Enabled     *bool                               `json:"enabled,omitempty"`
+	Name        *string                             `json:"name,omitempty"`
+	Source      *SiteWebProxySourceUpdateInput      `json:"source,omitempty"`
+}
+
+type SiteWebProxyTrafficUpdateRuleInput struct {
+	ID   string                                  `json:"id"`
+	Rule *SiteWebProxyTrafficUpdateRuleDataInput `json:"rule"`
+}
+
+type SiteWebProxyUpdateRuleDataInput struct {
+	AssociatedSite              []*SiteRefInput                              `json:"associatedSite,omitempty"`
+	AuthenticationConfig        *SiteWebProxyAuthenticationConfigUpdateInput `json:"authenticationConfig,omitempty"`
+	Description                 *string                                      `json:"description,omitempty"`
+	Enabled                     *bool                                        `json:"enabled,omitempty"`
+	Fqdn                        *string                                      `json:"fqdn,omitempty"`
+	Name                        *string                                      `json:"name,omitempty"`
+	Port                        *scalars.Port                                `json:"port,omitempty"`
+	ShouldAssociateWithAllSites *bool                                        `json:"shouldAssociateWithAllSites,omitempty"`
+}
+
+type SiteWebProxyUpdateRuleInput struct {
+	ID   string                           `json:"id"`
+	Rule *SiteWebProxyUpdateRuleDataInput `json:"rule"`
 }
 
 type SiteWorkingHours struct {
@@ -15046,6 +15474,9 @@ type UpdateHaInput struct {
 	PrimaryManagementIP   *string `json:"primaryManagementIp,omitempty"`
 	SecondaryManagementIP *string `json:"secondaryManagementIp,omitempty"`
 	Vrid                  *int64  `json:"vrid,omitempty"`
+	// Enable Cloud Router mode for a GCP vSocket HA site, using the Socket LAN interface for BGP peering.
+	// Only relevant for GCP HA sites; requires the account and Sockets to support the feature.
+	IsCloudRouter *bool `json:"isCloudRouter,omitempty"`
 }
 
 type UpdateHaPayload struct {
@@ -23847,13 +24278,13 @@ const (
 	EventFieldNameDomainName EventFieldName = "domain_name"
 	//  Duration in milliseconds between the start and end of a transaction or operation. For example, in DNS or HTTP events, this reflects the time between the request and the corresponding response. CMA Name: Duration Ms
 	EventFieldNameDurationMs EventFieldName = "duration_ms"
-	//  Dynamic Control IDs applied in the event. CMA Name: Dynamic Control IDs
+	//  Control IDs applied in the event. CMA Name: Control IDs
 	EventFieldNameDynamicControlIds EventFieldName = "dynamic_control_ids"
-	//  Dynamic control names applied in the event. CMA Name: Dynamic Control Names
+	//  Control names applied in the event. CMA Name: Control Names
 	EventFieldNameDynamicControlNames EventFieldName = "dynamic_control_names"
-	//  The scope of the dynamic control Applied in the event. CMA Name: Dynamic Control Scope
+	//  The scope of the control applied in the event. CMA Name: Dynamic Control Scope
 	EventFieldNameDynamicControlScope EventFieldName = "dynamic_control_scope"
-	//  Dynamic control threat categories applied in the event. CMA Name: Dynamic Control Threat Categories
+	//  Control threat categories applied in the event. CMA Name: Dynamic Control Threat Categories
 	EventFieldNameDynamicControlThreatCategories EventFieldName = "dynamic_control_threat_categories"
 	//  Egress PoP Name. CMA Name: Egress PoP Name
 	EventFieldNameEgressPopName EventFieldName = "egress_pop_name"
@@ -30355,6 +30786,125 @@ func (e *SiteType) UnmarshalJSON(b []byte) error {
 }
 
 func (e SiteType) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
+}
+
+// Action that the web proxy applies to traffic matching the rule.
+type SiteWebProxyAction string
+
+const (
+	//  Specifies that the web proxy should not authenticate users and should forward traffic as is.
+	SiteWebProxyActionAllow SiteWebProxyAction = "ALLOW"
+	//  Specifies that the web proxy should authenticate users using the chosen authentication method.
+	SiteWebProxyActionAuthenticate SiteWebProxyAction = "AUTHENTICATE"
+	//  Specifies that the web proxy should block the traffic.
+	SiteWebProxyActionBlock SiteWebProxyAction = "BLOCK"
+)
+
+var AllSiteWebProxyAction = []SiteWebProxyAction{
+	SiteWebProxyActionAllow,
+	SiteWebProxyActionAuthenticate,
+	SiteWebProxyActionBlock,
+}
+
+func (e SiteWebProxyAction) IsValid() bool {
+	switch e {
+	case SiteWebProxyActionAllow, SiteWebProxyActionAuthenticate, SiteWebProxyActionBlock:
+		return true
+	}
+	return false
+}
+
+func (e SiteWebProxyAction) String() string {
+	return string(e)
+}
+
+func (e *SiteWebProxyAction) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = SiteWebProxyAction(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid SiteWebProxyAction", str)
+	}
+	return nil
+}
+
+func (e SiteWebProxyAction) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+func (e *SiteWebProxyAction) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e SiteWebProxyAction) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
+}
+
+// Authentication method used by the web proxy.
+type SiteWebProxyAuthMethod string
+
+const (
+	//  Kerberos (keytab-based) authentication.
+	SiteWebProxyAuthMethodKerberos SiteWebProxyAuthMethod = "KERBEROS"
+	//  No authentication - traffic is forwarded without authenticating users.
+	SiteWebProxyAuthMethodNone SiteWebProxyAuthMethod = "NONE"
+)
+
+var AllSiteWebProxyAuthMethod = []SiteWebProxyAuthMethod{
+	SiteWebProxyAuthMethodKerberos,
+	SiteWebProxyAuthMethodNone,
+}
+
+func (e SiteWebProxyAuthMethod) IsValid() bool {
+	switch e {
+	case SiteWebProxyAuthMethodKerberos, SiteWebProxyAuthMethodNone:
+		return true
+	}
+	return false
+}
+
+func (e SiteWebProxyAuthMethod) String() string {
+	return string(e)
+}
+
+func (e *SiteWebProxyAuthMethod) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = SiteWebProxyAuthMethod(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid SiteWebProxyAuthMethod", str)
+	}
+	return nil
+}
+
+func (e SiteWebProxyAuthMethod) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+func (e *SiteWebProxyAuthMethod) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e SiteWebProxyAuthMethod) MarshalJSON() ([]byte, error) {
 	var buf bytes.Buffer
 	e.MarshalGQL(&buf)
 	return buf.Bytes(), nil


### PR DESCRIPTION
## Summary
- Refreshes cato_api.graphqls from the upstream Cato schema endpoint.
- Applies and validates schema patches, deleting patch files that upstream now includes.
- Regenerates the Go SDK client/models and verifies `go build ./...`.

## Test plan
- `bash scripts/schema_update_ci.sh`
